### PR TITLE
[BE] FEAT, FIX: IdDomain을 복합 키로도 관리할 수 있도록 확장

### DIFF
--- a/backend/src/main/java/proj/pet/board/domain/Board.java
+++ b/backend/src/main/java/proj/pet/board/domain/Board.java
@@ -9,7 +9,7 @@ import proj.pet.comment.domain.Comment;
 import proj.pet.member.domain.Member;
 import proj.pet.reaction.domain.Reaction;
 import proj.pet.scrap.domain.Scrap;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -24,7 +24,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "BOARD")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Board extends IdDomain implements Validatable {
+public class Board extends IdentityDomain implements Validatable {
 
 	@OneToMany(mappedBy = "board",
 			targetEntity = BoardMedia.class,

--- a/backend/src/main/java/proj/pet/board/domain/BoardMedia.java
+++ b/backend/src/main/java/proj/pet/board/domain/BoardMedia.java
@@ -3,7 +3,7 @@ package proj.pet.board.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "BOARD_MEDIA")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class BoardMedia extends IdDomain implements Validatable {
+public class BoardMedia extends IdentityDomain implements Validatable {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "BOARD_ID", nullable = false, updatable = false)

--- a/backend/src/main/java/proj/pet/category/domain/AnimalCategory.java
+++ b/backend/src/main/java/proj/pet/category/domain/AnimalCategory.java
@@ -3,7 +3,7 @@ package proj.pet.category.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "ANIMAL_CATEGORY")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class AnimalCategory extends IdDomain implements Validatable {
+public class AnimalCategory extends IdentityDomain implements Validatable {
 
 	private static final int MAX_NAME_LENGTH = 32;
 

--- a/backend/src/main/java/proj/pet/category/domain/BoardCategoryFilter.java
+++ b/backend/src/main/java/proj/pet/category/domain/BoardCategoryFilter.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.utils.domain.ConsumptionCompositeKey;
+import proj.pet.utils.domain.IdDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -15,10 +16,10 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Table(name = "BOARD_CATEGORY_FILTER")
 @Getter
-public class BoardCategoryFilter implements Validatable {
+public class BoardCategoryFilter extends IdDomain<ConsumptionCompositeKey> implements Validatable {
 
 	@EmbeddedId
-	private ConsumptionCompositeKey key;
+	private ConsumptionCompositeKey id;
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "CONSUMER_ID", nullable = false, insertable = false, updatable = false)
@@ -29,7 +30,7 @@ public class BoardCategoryFilter implements Validatable {
 	private AnimalCategory animalCategory;
 
 	private BoardCategoryFilter(Board board, AnimalCategory animalCategory) {
-		this.key = ConsumptionCompositeKey.of(board.getId(), animalCategory.getId());
+		this.id = ConsumptionCompositeKey.of(board.getId(), animalCategory.getId());
 		this.board = board;
 		this.animalCategory = animalCategory;
 		RuntimeExceptionThrower.checkValidity(this);

--- a/backend/src/main/java/proj/pet/category/domain/MemberCategoryFilter.java
+++ b/backend/src/main/java/proj/pet/category/domain/MemberCategoryFilter.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
 import proj.pet.utils.domain.ConsumptionCompositeKey;
+import proj.pet.utils.domain.IdDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -15,9 +16,9 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "MEMBER_CATEGORY_FILTER")
 @Getter
 @Entity
-public class MemberCategoryFilter implements Validatable {
+public class MemberCategoryFilter extends IdDomain<ConsumptionCompositeKey> implements Validatable {
 	@EmbeddedId
-	private ConsumptionCompositeKey key;
+	private ConsumptionCompositeKey id;
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "CONSUMER_ID", nullable = false, insertable = false, updatable = false)
@@ -28,7 +29,7 @@ public class MemberCategoryFilter implements Validatable {
 	private AnimalCategory animalCategory;
 
 	private MemberCategoryFilter(Member member, AnimalCategory animalCategory) {
-		this.key = ConsumptionCompositeKey.of(member.getId(), animalCategory.getId());
+		this.id = ConsumptionCompositeKey.of(member.getId(), animalCategory.getId());
 		this.member = member;
 		this.animalCategory = animalCategory;
 		RuntimeExceptionThrower.checkValidity(this);

--- a/backend/src/main/java/proj/pet/comment/domain/Comment.java
+++ b/backend/src/main/java/proj/pet/comment/domain/Comment.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.member.domain.Member;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "COMMENT")
 @Getter
-public class Comment extends IdDomain implements Validatable {
+public class Comment extends IdentityDomain implements Validatable {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "BOARD_ID", nullable = false, updatable = false)

--- a/backend/src/main/java/proj/pet/follow/domain/Follow.java
+++ b/backend/src/main/java/proj/pet/follow/domain/Follow.java
@@ -1,27 +1,23 @@
 package proj.pet.follow.domain;
 
-import static lombok.AccessLevel.PROTECTED;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
+import proj.pet.utils.domain.IdDomain;
 import proj.pet.utils.domain.MemberCompositeKey;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "FOLLOW")
 @Getter
-public class Follow implements Validatable {
+public class Follow extends IdDomain<MemberCompositeKey> implements Validatable {
 
 	@EmbeddedId
 	private MemberCompositeKey id;

--- a/backend/src/main/java/proj/pet/member/domain/Member.java
+++ b/backend/src/main/java/proj/pet/member/domain/Member.java
@@ -9,7 +9,7 @@ import proj.pet.category.domain.MemberCategoryFilter;
 import proj.pet.follow.domain.Follow;
 import proj.pet.reaction.domain.Reaction;
 import proj.pet.scrap.domain.Scrap;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -25,7 +25,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "MEMBER")
 @Getter
 @ToString
-public class Member extends IdDomain implements Validatable {
+public class Member extends IdentityDomain implements Validatable {
 
 	@Embedded
 	private OauthProfile oauthProfile;
@@ -69,42 +69,42 @@ public class Member extends IdDomain implements Validatable {
 			fetch = LAZY,
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
-	private List<Block> blocks = new ArrayList<>();
+	private final List<Block> blocks = new ArrayList<>();
 
 	@ToString.Exclude
 	@OneToMany(mappedBy = "from",
 			fetch = LAZY,
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
-	private List<Follow> followings = new ArrayList<>();
+	private final List<Follow> followings = new ArrayList<>();
 
 	@ToString.Exclude
 	@OneToMany(mappedBy = "to",
 			fetch = LAZY,
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
-	private List<Follow> followers = new ArrayList<>();
+	private final List<Follow> followers = new ArrayList<>();
 
 	@ToString.Exclude
 	@OneToMany(mappedBy = "member",
 			fetch = LAZY,
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
-	private List<MemberCategoryFilter> memberCategoryFilters = new ArrayList<>();
+	private final List<MemberCategoryFilter> memberCategoryFilters = new ArrayList<>();
 
 	@ToString.Exclude
 	@OneToMany(mappedBy = "member",
 			fetch = LAZY,
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
-	private List<Reaction> reactions = new ArrayList<>();
+	private final List<Reaction> reactions = new ArrayList<>();
 
 	@ToString.Exclude
 	@OneToMany(mappedBy = "member",
 			fetch = LAZY,
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
-	private List<Scrap> scraps = new ArrayList<>();
+	private final List<Scrap> scraps = new ArrayList<>();
 
 	private Member(OauthProfile oauthProfile, Country country, Country.Campus campus, Language language, String nickname,
 	               String statement, MemberRole memberRole, LocalDateTime now) {

--- a/backend/src/main/java/proj/pet/reaction/domain/Reaction.java
+++ b/backend/src/main/java/proj/pet/reaction/domain/Reaction.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.member.domain.Member;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -19,7 +19,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "REACTION",
 		uniqueConstraints = {@UniqueConstraint(name = "UNIQUE_REACTION", columnNames = {"MEMBER_ID", "BOARD_ID"})})
 @Getter
-public class Reaction extends IdDomain implements Validatable {
+public class Reaction extends IdentityDomain implements Validatable {
 
 	@Column(name = "MEMBER_ID", nullable = false, insertable = false, updatable = false)
 	private Long memberId;

--- a/backend/src/main/java/proj/pet/report/domain/Report.java
+++ b/backend/src/main/java/proj/pet/report/domain/Report.java
@@ -1,24 +1,18 @@
 package proj.pet.report.domain;
 
-import static jakarta.persistence.FetchType.LAZY;
-import static lombok.AccessLevel.PROTECTED;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import proj.pet.member.domain.Member;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
 @Entity
@@ -31,7 +25,7 @@ import proj.pet.utils.domain.Validatable;
 		})
 @Getter
 @ToString
-public class Report extends IdDomain implements Validatable {
+public class Report extends IdentityDomain implements Validatable {
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "MEMBER_ID", nullable = false, updatable = false)
@@ -67,19 +61,19 @@ public class Report extends IdDomain implements Validatable {
 	}
 
 	public static Report ofMember(Member from, Member to, ReportReason reason, String content,
-			LocalDateTime now) {
+	                              LocalDateTime now) {
 		return new Report(from, to, reason, content, now);
 	}
 
 	public static Report ofBoard(Member from, Member to, Long boardId, ReportReason reason,
-			String content, LocalDateTime now) {
+	                             String content, LocalDateTime now) {
 		Report report = new Report(from, to, reason, content, now);
 		report.boardId = boardId;
 		return report;
 	}
 
 	public static Report ofComment(Member from, Member to, Long boardId, Long commentId,
-			ReportReason reason, String content, LocalDateTime now) {
+	                               ReportReason reason, String content, LocalDateTime now) {
 		Report report = new Report(from, to, reason, content, now);
 		report.boardId = boardId;
 		report.commentId = commentId;

--- a/backend/src/main/java/proj/pet/scrap/domain/Scrap.java
+++ b/backend/src/main/java/proj/pet/scrap/domain/Scrap.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.member.domain.Member;
-import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.IdentityDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
@@ -18,7 +18,7 @@ import static lombok.AccessLevel.PROTECTED;
 		uniqueConstraints = {@UniqueConstraint(name = "UNIQUE_SCRAP", columnNames = {"MEMBER_ID", "BOARD_ID"})})
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Scrap extends IdDomain implements Validatable {
+public class Scrap extends IdentityDomain implements Validatable {
 
 	@Column(name = "MEMBER_ID", nullable = false, insertable = false, updatable = false)
 	private Long memberId;

--- a/backend/src/main/java/proj/pet/utils/domain/IdDomain.java
+++ b/backend/src/main/java/proj/pet/utils/domain/IdDomain.java
@@ -27,7 +27,9 @@ public abstract class IdDomain<ID extends Serializable> implements Persistable<I
 	private boolean isNew = true;
 
 	/**
-	 * Long 타입 Id를 갖는 엔티티의 경우, Equals와 HashCode는 고정이므로, final로 선언합니다.
+	 * 프록시 객체인 경우에 대한 처리를 위해 {@link HibernateProxy}를 사용합니다.
+	 * <p>
+	 * 영속화 된 엔티티의 ID 와 비교합니다.
 	 */
 	@Override
 	public boolean equals(Object o) {
@@ -40,8 +42,8 @@ public abstract class IdDomain<ID extends Serializable> implements Persistable<I
 		}
 		@SuppressWarnings("unchecked")
 		Serializable oid = o instanceof HibernateProxy
-				? (Serializable) ((HibernateProxy) o).getHibernateLazyInitializer().getIdentifier() :
-				((IdDomain<ID>) o).getId();
+				? (Serializable) ((HibernateProxy) o).getHibernateLazyInitializer().getIdentifier()
+				: ((IdDomain<ID>) o).getId();
 		return getId().equals(oid);
 	}
 

--- a/backend/src/main/java/proj/pet/utils/domain/IdentityDomain.java
+++ b/backend/src/main/java/proj/pet/utils/domain/IdentityDomain.java
@@ -1,0 +1,17 @@
+package proj.pet.utils.domain;
+
+import jakarta.persistence.*;
+import lombok.ToString;
+
+@MappedSuperclass
+@ToString
+public abstract class IdentityDomain extends IdDomain<Long> {
+	@Id @Column(name = "ID")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id = null;
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42pet/issues/123

https://github.com/42pet/42pet/issues/

- 기존의 IdDomain(Long 타입)만 관리하던 것을 제네릭을 이용해서 CompositeKey인 경우에도 일괄적으로 관리할 수 있도록 확장
- IdDomain -> IdentityDomain(<Long>), IdDomain<ID>와 같은 방식으로 쪼갬

위 방식을 통해서 도메인 엔티티와 관련한 유틸 클래스나 로직 작성 시에 제네릭으로 관리하기 용이하다는 점이 있음.
-> E2E 통합 테스트를 할 때 persist를 용이하게 해주는 유틸 클래스를 작성할 때 사용하기 위함

shout out to dongglee( 42 seoul member )