### PR TITLE
[FE] FEAT: 비로그인 상태 언어 설정 및 동물 카테고리 업데이트를 위한 localStorage 추가

### DIFF
--- a/frontend/src/components/RightSection/AnimalFilterSection/AnimalFilterSection.tsx
+++ b/frontend/src/components/RightSection/AnimalFilterSection/AnimalFilterSection.tsx
@@ -8,32 +8,46 @@ import { AnimalSpecies } from "@/types/enum/animal.filter.enum";
 import { axiosUpdateAnimalCategory } from "@/api/axios/axios.custom";
 import useToaster from "@/hooks/useToaster";
 import useRightSectionHandler from "@/hooks/useRightSectionHandler";
+import { useQueryClient } from "@tanstack/react-query";
+import { boardCategoryState } from "@/recoil/atom";
+import { Board } from "@/types/enum/board.category.enum";
 
 const AnimalFilterSection = () => {
   const [userInfo] = useRecoilState<UserInfoDTO | null>(userInfoState);
   const [animalCategory, setAnimalCategory] = useState<AnimalSpecies[] | null>(
     null
   );
+  const [boardCategory] = useRecoilState<Board>(boardCategoryState);
+  const queryClient = useQueryClient();
   const { popToast } = useToaster();
   const { closeRightSection } = useRightSectionHandler();
 
   useEffect(() => {
-    if (userInfo) setAnimalCategory(userInfo.animalCategories);
-    if (!userInfo)
-      setAnimalCategory([
-        AnimalSpecies.DOG,
-        AnimalSpecies.AMPHIBIAN,
-        AnimalSpecies.BIRD,
-        AnimalSpecies.CAT,
-        AnimalSpecies.FISH,
-        AnimalSpecies.INSECT,
-        AnimalSpecies.REPTILE,
-        AnimalSpecies.SMALLANIMAL,
-      ]);
+    //로그인 상태에서 유저 정보 카테고리 불러오기
+    if (userInfo) {
+      setAnimalCategory(userInfo.animalCategories);
+      return;
+    }
+    const localCategoryValue = localStorage.getItem("animal_category");
+    // 로그아웃 상태에서 로컬 스토리지에 저장되어 있는 카테고리 불러오기
+    if (!userInfo && localCategoryValue) {
+      const localCategory: AnimalSpecies[] = JSON.parse(localCategoryValue);
+      setAnimalCategory(localCategory);
+      // 로그아웃 상태에서 로컬 스토리지 기록 없을 시, 기본 카테고리 값(모든 동물)
+    } else {
+      const allAnimalSpecies = Object.values(AnimalSpecies);
+      setAnimalCategory(allAnimalSpecies);
+    }
   }, []);
 
-  const handleOnClick = () => {
-    axiosUpdateAnimalCategory(animalCategory as AnimalSpecies[]);
+  const updateAnimalCategory = () => {
+    // 로그인 상태 -> api에 실제 데이터 변경 요청
+    if (userInfo) axiosUpdateAnimalCategory(animalCategory as AnimalSpecies[]);
+    // 로그아웃 상태 -> 로컬 스토리지에 새로 업데이트할 카테고리 등록
+    else {
+      localStorage.setItem("animal_category", JSON.stringify(animalCategory));
+      queryClient.invalidateQueries(["boards", boardCategory]);
+    }
     closeRightSection();
     popToast("동물 카테고리가 변경되었습니다.", "P");
   };
@@ -51,7 +65,9 @@ const AnimalFilterSection = () => {
           setter={setAnimalCategory}
         />
       )}
-      <SubmitButtonStyled onClick={handleOnClick}>확인</SubmitButtonStyled>
+      <SubmitButtonStyled onClick={updateAnimalCategory}>
+        확인
+      </SubmitButtonStyled>
     </WrapperStyled>
   );
 };

--- a/frontend/src/components/modals/LanguageModal/LanguageModal.tsx
+++ b/frontend/src/components/modals/LanguageModal/LanguageModal.tsx
@@ -6,11 +6,15 @@ import { currentOpenModalState } from "@/recoil/atom";
 import { ICurrentModalStateInfo } from "@/types/interface/modal.interface";
 import { Language } from "@/types/enum/language.enum";
 import { languageState } from "@/recoil/atom";
-import Translator from "@/languages/Translator";
 import useModal from "@/hooks/useModal";
 import useToaster from "@/hooks/useToaster";
 import { axiosChangeLanguage } from "@/api/axios/axios.custom";
 import { getCookie } from "@/api/cookie/cookies";
+import {
+  languages,
+  renderLanguage,
+  languageTranslator,
+} from "./languageModalUtils";
 
 const token = getCookie("access_token");
 
@@ -21,51 +25,16 @@ const LanguageModal = () => {
   const [language, setLanguage] = useRecoilState<any>(languageState);
   const { closeModal } = useModal();
   const { popToast } = useToaster();
-  const languages: Language[] = [
-    Language.KOREAN,
-    Language.ENGLISH,
-    Language.JAPANESE,
-    Language.SPANISH,
-    Language.FRENCH,
-    Language.GERMAN,
-    Language.ITALIAN,
-    Language.PORTUGUESE,
-  ];
 
-  const renderLanguage = (renderLanguage: Language) => {
-    if (renderLanguage === Language.KOREAN) return "🇰🇷 한국어";
-    if (renderLanguage === Language.ENGLISH) return "🇬🇧 English";
-    if (renderLanguage === Language.JAPANESE) return "🇯🇵 日本語";
-    if (renderLanguage === Language.SPANISH) return "🇪🇸 español";
-    if (renderLanguage === Language.FRENCH) return "🇫🇷 français";
-    if (renderLanguage === Language.GERMAN) return "🇩🇪 Deutsch";
-    if (renderLanguage === Language.ITALIAN) return "🇮🇹 italiano";
-    if (renderLanguage === Language.PORTUGUESE) return "🇵🇹 Português";
-  };
+  const updateLanguageSetting = (currentLanguage: Language) => {
+    const translatedLanguage = languageTranslator[currentLanguage];
 
-  const handleLanguageSetting = (currentLanguage: Language) => {
-    let translatedLanguage = null;
-
-    if (currentLanguage === Language.KOREAN) {
-      translatedLanguage = Translator.ko;
-    } else if (currentLanguage === Language.ENGLISH) {
-      translatedLanguage = Translator.en;
-    } else if (currentLanguage === Language.JAPANESE) {
-      translatedLanguage = Translator.jp;
-    } else if (currentLanguage === Language.SPANISH) {
-      translatedLanguage = Translator.spa;
-    } else if (currentLanguage === Language.FRENCH) {
-      translatedLanguage = Translator.fr;
-    } else if (currentLanguage === Language.GERMAN) {
-      translatedLanguage = Translator.ger;
-    } else if (currentLanguage === Language.ITALIAN) {
-      translatedLanguage = Translator.it;
-    } else if (currentLanguage === Language.PORTUGUESE) {
-      translatedLanguage = Translator.pt;
-    }
     if (translatedLanguage) {
       setLanguage(translatedLanguage);
+      //로그인 상태 -> 실제 서버 api 요청 후 유저 언어 설정 변경
       if (token) axiosChangeLanguage(currentLanguage);
+      // 로그아웃 상태 -> 로컬 스토리지에 비로그인 상태 언어 설정 업데이트
+      if (!token) localStorage.setItem("language", currentLanguage);
       popToast(translatedLanguage.languageChangedToast, "P");
     }
     closeModal(ModalType.LANGUAGE);
@@ -83,9 +52,9 @@ const LanguageModal = () => {
           {languages.map((language) => (
             <LanguageItemStyled
               key={language}
-              onClick={() => handleLanguageSetting(language)}
+              onClick={() => updateLanguageSetting(language)}
             >
-              {renderLanguage(language)}
+              {renderLanguage[language]}
             </LanguageItemStyled>
           ))}
         </LanguageItemContainerStyled>
@@ -136,7 +105,6 @@ const LanguageItemStyled = styled.button`
   border: none;
   font-size: 1.2rem;
   background-color: var(--white);
-
   &:hover {
     background-color: var(--lightpurple);
     transition: background-color 0.5s ease;

--- a/frontend/src/components/modals/LanguageModal/languageModalUtils.ts
+++ b/frontend/src/components/modals/LanguageModal/languageModalUtils.ts
@@ -1,0 +1,38 @@
+import { Language } from "@/types/enum/language.enum";
+import Translator from "@/languages/Translator";
+
+//v1에서 지원하고 있는 언어 목록
+export const languages: Language[] = [
+  Language.KOREAN,
+  Language.ENGLISH,
+  Language.JAPANESE,
+  Language.SPANISH,
+  Language.FRENCH,
+  Language.GERMAN,
+  Language.ITALIAN,
+  Language.PORTUGUESE,
+];
+
+//실제 클라이언트 화면에 렌더링될 언어 + 국기
+export const renderLanguage = {
+  [Language.KOREAN]: "🇰🇷 한국어",
+  [Language.ENGLISH]: "🇬🇧 English",
+  [Language.JAPANESE]: "🇯🇵 日本語",
+  [Language.SPANISH]: "🇪🇸 español",
+  [Language.FRENCH]: "🇫🇷 français",
+  [Language.GERMAN]: "🇩🇪 Deutsch",
+  [Language.ITALIAN]: "🇮🇹 italiano",
+  [Language.PORTUGUESE]: "🇵🇹 Português",
+};
+
+//language(recoil state)를 실제 변경해 줄 딕셔너리
+export const languageTranslator = {
+  [Language.KOREAN]: Translator.ko,
+  [Language.ENGLISH]: Translator.en,
+  [Language.JAPANESE]: Translator.jp,
+  [Language.SPANISH]: Translator.spa,
+  [Language.FRENCH]: Translator.fr,
+  [Language.GERMAN]: Translator.ger,
+  [Language.ITALIAN]: Translator.it,
+  [Language.PORTUGUESE]: Translator.pt,
+};

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { isRightSectionOpenedState } from "@/recoil/atom";
 import LeftMenuSection from "@/components/LeftMenuSection/LeftMenuSection";
@@ -12,22 +12,22 @@ import { getCookie } from "@/api/cookie/cookies";
 import { axiosMyInfo } from "@/api/axios/axios.custom";
 import { userInfoState } from "@/recoil/atom";
 import { UserInfoDTO } from "@/types/dto/member.dto";
-import { languageState } from "@/recoil/atom";
 import useTranslator from "@/hooks/useTranslator";
+import { Language } from "@/types/enum/language.enum";
 
 const Layout = () => {
   const location = useLocation();
   const token = getCookie("access_token");
+  const localLanguage = localStorage.getItem("language");
   const [userInfo, setUserInfo] = useRecoilState<UserInfoDTO | null>(
     userInfoState
   );
-  const setLanugage = useSetRecoilState(languageState);
   const [isRightSectionOpened] = useRecoilState<boolean>(
     isRightSectionOpenedState
   );
   const { translator } = useTranslator();
 
-  /**메인 화면일 때만 게시글 정렬 버튼 보여주기*/
+  //메인 화면일 때만 게시글 정렬 버튼 보여주기
   const isMainPage: boolean = location.pathname === "/";
   const isSignUpPage: boolean = location.pathname === "/sign-up";
   const isProfilePage: boolean =
@@ -44,9 +44,10 @@ const Layout = () => {
   };
 
   useEffect(() => {
-    if (token && !userInfo) {
-      getMyInfo();
-    }
+    //로그인 성공 시 유저 정보 받아오기
+    if (token && !userInfo) getMyInfo();
+    //비로그인 상태에서 로컬 스토리지 키값을 통해 언어 설정
+    if (!token && localLanguage) translator(localLanguage as Language);
   }, []);
 
   return isSignUpPage ? (


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

    비로그인 상태에서 새로고침 및 기타 요인으로 인해 세션이 날라갔을 때(클라이언트 측 상태 관리가 초기화되었을 때) 업데이트한 언어 설정 및 동물 카테고리를 유지하기 위한 로컬 스토리지를 추가하였습니다.

    토큰 유무를 확인해 토큰이 존재한다면 서버 api에 axios 요청을 날리고, 존재하지 않는다면 localStorage를 업데이트해 주는 방식으로 진행하였습니다.

    추가적으로 해당 컴포넌트들에 대한 리팩토링 및 주석 달기 또한 진행했습니다.

https://github.com/42pet/42pet/issues/70
