### PR TITLE
[FE] FEAT: 무한 스크롤 도입 및 401 에러 핸들링

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
+        "react-infinite-scroll-component": "^6.1.0",
         "react-intersection-observer": "^9.5.2",
         "react-router-dom": "^6.13.0",
         "recoil": "^0.7.7",
@@ -9839,6 +9840,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "dependencies": {
+        "throttle-debounce": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/react-intersection-observer": {
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
@@ -10879,6 +10891,14 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "optional": true,
       "peer": true
+    },
+    "node_modules/throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/through2": {
       "version": "2.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-intersection-observer": "^9.5.2",
     "react-router-dom": "^6.13.0",
     "recoil": "^0.7.7",

--- a/frontend/src/components/Board/BoardPhotoBox.tsx
+++ b/frontend/src/components/Board/BoardPhotoBox.tsx
@@ -15,7 +15,7 @@ const BoardPhotoBox = ({
 }) => {
   return (
     <WrapperStyled>
-      <PhotoZoneStyled onDoubleClick={handleClickReaction}>
+      <PhotoZoneStyled>
         <Swiper
           modules={[Navigation, Pagination, A11y]}
           slidesPerView={1}
@@ -26,7 +26,11 @@ const BoardPhotoBox = ({
         >
           {boardImages.map((boardImage, index) => (
             <SwiperSlide key={index}>
-              <img src={boardImage} alt={`Image ${index}`} />
+              <img
+                src={boardImage}
+                alt={`Image ${index}`}
+                onDoubleClick={handleClickReaction}
+              />
             </SwiperSlide>
           ))}
         </Swiper>

--- a/frontend/src/components/Board/BoardTemplate.tsx
+++ b/frontend/src/components/Board/BoardTemplate.tsx
@@ -81,23 +81,35 @@ const BoardTemplate = (board: IBoardInfo) => {
     openModal(ModalType.PROFILECARD);
   };
 
-  const callReactionApi = () => {
-    if (!isReactedRender && !lastReaction) {
-      axiosReactComment(boardId, "LIKE");
+  const callReactionApi = async () => {
+    try {
+      let response;
+      if (!isReactedRender && !lastReaction)
+        response = await axiosReactComment(boardId, "LIKE");
+      else if (isReactedRender && lastReaction)
+        response = await axiosUndoReactComment(boardId);
+
       setLastReaction(!lastReaction);
-    } else if (isReactedRender && lastReaction) {
-      axiosUndoReactComment(boardId);
-      setLastReaction(!lastReaction);
+    } catch (error) {
+      //401 발생 -> 기존 isReactedRender 롤백
+      setReactionCountRender(reactionCount);
+      setIsReactedRender((prev) => !prev);
     }
   };
 
-  const callScrapApi = () => {
-    if (!isScrappedRender && !lastScrap) {
-      axiosScrap(boardId);
-      setLastScrap(!lastScrap);
-    } else if (isScrappedRender && lastScrap) {
-      axiosUndoScrap(boardId);
-      setLastScrap(!lastScrap);
+  const callScrapApi = async () => {
+    try {
+      let response;
+      if (!isScrappedRender && !lastScrap) {
+        response = await axiosScrap(boardId);
+        setLastScrap(!lastScrap);
+      } else if (isScrappedRender && lastScrap) {
+        response = await axiosUndoScrap(boardId);
+        setLastScrap(!lastScrap);
+      }
+    } catch (error) {
+      //401 발생 -> 기존 isReactedRender 롤백
+      setIsScrappedRender((prev) => !prev);
     }
   };
 

--- a/frontend/src/components/BoardOption.tsx
+++ b/frontend/src/components/BoardOption.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSetRecoilState, useRecoilState } from "recoil";
 import styled from "styled-components";
 import { ModalType } from "@/types/enum/modal.enum";
@@ -15,16 +15,18 @@ import { reportUserInfoState } from "@/recoil/atom";
 import { ReportDTO } from "@/types/dto/member.dto";
 
 /**
- * @boardId (optional) 신고, 차단, 삭제할 게시물의 id
- * @commendId (optional) 신고, 차단, 삭제할 댓글의 id
- * @memberId 신고, 차단, 삭제할 댓글 혹은 게시물의 유저 id
- * @memberName 차단 모달에 띄위게 될 차단 유저명
+ * @param {number} boardId - 신고, 차단, 삭제할 게시물의 id (optional)
+ * @param {number} commentId - 신고, 차단, 삭제할 댓글의 id (optional)
+ * @param {number} memberId - 신고, 차단, 삭제할 댓글 혹은 게시물의 유저 id
+ * @param {string} membername - 차단 모달에 띄우게 될 차단 유저명
+ * @param {Function} callback - 상태 업데이트 후 실행시킬 콜백 함수(ex.리렌더링) (optional)
  */
 interface IOptionButtonProps {
   boardId?: number;
   commentId?: number;
   memberId: number;
   memberName: string;
+  callback?: () => void;
 }
 
 /**게시글 및 댓글 오른쪽 상단 ... 버튼. 타인 게시물 댓글에서는 신고 차단, 내 게시물에서는 삭제가 나타남*/
@@ -33,6 +35,7 @@ const BoardOption: React.FC<IOptionButtonProps> = ({
   commentId,
   memberId,
   memberName,
+  callback,
 }) => {
   const [language] = useRecoilState<any>(languageState);
   const setBanUserInfo = useSetRecoilState<IBanUserInfo>(banUserInfoState);
@@ -42,7 +45,11 @@ const BoardOption: React.FC<IOptionButtonProps> = ({
   const setDeleteInfo = useSetRecoilState<IDeleteInfo>(deleteInfoState);
   const { openModal } = useModal();
 
-  const banUser = { memberId: memberId, userName: memberName };
+  const banUser = {
+    memberId: memberId,
+    userName: memberName,
+    callback: callback,
+  };
 
   const handleBan = () => {
     setBanUserInfo(banUser);

--- a/frontend/src/components/LeftMenuSection/LeftMenuSection.tsx
+++ b/frontend/src/components/LeftMenuSection/LeftMenuSection.tsx
@@ -9,6 +9,7 @@ import useNavigateCustom from "@/hooks/useNavigateCustom";
 import { boardCategoryState } from "@/recoil/atom";
 import { Board } from "@/types/enum/board.category.enum";
 import { useQueryClient } from "@tanstack/react-query";
+import LoadingAnimation from "../loading/LoadingAnimation";
 
 export interface LeftMenuProps {
   handleLogin: () => void;
@@ -28,7 +29,7 @@ const LeftMenuSection = () => {
     useRecoilState<Board>(boardCategoryState);
   const queryClient = useQueryClient();
   const { moveToMain } = useNavigateCustom();
-
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
   useEffect(() => {
     const handleResize = () => {
       setIsDesktopScreen(window.matchMedia("(min-width: 1024px)").matches);
@@ -41,6 +42,7 @@ const LeftMenuSection = () => {
 
   const handleLogin = () => {
     window.location.replace(`${import.meta.env.VITE_AUTH_LOGIN}`);
+    setIsLoggingIn(true);
   };
 
   const handleLogout = () => {
@@ -59,21 +61,26 @@ const LeftMenuSection = () => {
     queryClient.invalidateQueries(["boards", boardCategory]);
   };
 
-  return isDesktopScreen ? (
-    <LeftMenuDesktop
-      handleLogin={handleLogin}
-      handleLogout={handleLogout}
-      handleClickLogo={handleClickLogo}
-      userInfo={userInfo}
-      language={language}
-    />
-  ) : (
-    <LeftMenuTablet
-      handleLogin={handleLogin}
-      handleLogout={handleLogout}
-      handleClickLogo={handleClickLogo}
-      userInfo={userInfo}
-    />
+  return (
+    <>
+      {isLoggingIn && <LoadingAnimation />}
+      {isDesktopScreen ? (
+        <LeftMenuDesktop
+          handleLogin={handleLogin}
+          handleLogout={handleLogout}
+          handleClickLogo={handleClickLogo}
+          userInfo={userInfo}
+          language={language}
+        />
+      ) : (
+        <LeftMenuTablet
+          handleLogin={handleLogin}
+          handleLogout={handleLogout}
+          handleClickLogo={handleClickLogo}
+          userInfo={userInfo}
+        />
+      )}
+    </>
   );
 };
 

--- a/frontend/src/components/OptionButton.tsx
+++ b/frontend/src/components/OptionButton.tsx
@@ -65,7 +65,6 @@ const MenuStyled = styled.div<{ $isToggled: boolean }>`
   text-align: center;
   margin-top: 25px;
   min-width: 45px;
-
   border-radius: 10px;
   color: var(--grey);
   background: var(--white);

--- a/frontend/src/components/RightSection/AnimalFilterSection/AnimalFilterSection.tsx
+++ b/frontend/src/components/RightSection/AnimalFilterSection/AnimalFilterSection.tsx
@@ -8,17 +8,12 @@ import { AnimalSpecies } from "@/types/enum/animal.filter.enum";
 import { axiosUpdateAnimalCategory } from "@/api/axios/axios.custom";
 import useToaster from "@/hooks/useToaster";
 import useRightSectionHandler from "@/hooks/useRightSectionHandler";
-import { useQueryClient } from "@tanstack/react-query";
-import { boardCategoryState } from "@/recoil/atom";
-import { Board } from "@/types/enum/board.category.enum";
 
 const AnimalFilterSection = () => {
   const [userInfo] = useRecoilState<UserInfoDTO | null>(userInfoState);
   const [animalCategory, setAnimalCategory] = useState<AnimalSpecies[] | null>(
     null
   );
-  const [boardCategory] = useRecoilState<Board>(boardCategoryState);
-  const queryClient = useQueryClient();
   const { popToast } = useToaster();
   const { closeRightSection } = useRightSectionHandler();
 
@@ -28,28 +23,17 @@ const AnimalFilterSection = () => {
       setAnimalCategory(userInfo.animalCategories);
       return;
     }
-    const localCategoryValue = localStorage.getItem("animal_category");
-    // 로그아웃 상태에서 로컬 스토리지에 저장되어 있는 카테고리 불러오기
-    if (!userInfo && localCategoryValue) {
-      const localCategory: AnimalSpecies[] = JSON.parse(localCategoryValue);
-      setAnimalCategory(localCategory);
-      // 로그아웃 상태에서 로컬 스토리지 기록 없을 시, 기본 카테고리 값(모든 동물)
-    } else {
-      const allAnimalSpecies = Object.values(AnimalSpecies);
-      setAnimalCategory(allAnimalSpecies);
-    }
+    const allAnimalSpecies = Object.values(AnimalSpecies);
+    setAnimalCategory(allAnimalSpecies);
   }, []);
 
   const updateAnimalCategory = () => {
     // 로그인 상태 -> api에 실제 데이터 변경 요청
-    if (userInfo) axiosUpdateAnimalCategory(animalCategory as AnimalSpecies[]);
-    // 로그아웃 상태 -> 로컬 스토리지에 새로 업데이트할 카테고리 등록
-    else {
-      localStorage.setItem("animal_category", JSON.stringify(animalCategory));
-      queryClient.invalidateQueries(["boards", boardCategory]);
+    if (userInfo) {
+      axiosUpdateAnimalCategory(animalCategory as AnimalSpecies[]);
+      popToast("동물 카테고리가 변경되었습니다.", "P");
     }
     closeRightSection();
-    popToast("동물 카테고리가 변경되었습니다.", "P");
   };
 
   return (

--- a/frontend/src/components/RightSection/SearchSection/SearchItem.tsx
+++ b/frontend/src/components/RightSection/SearchSection/SearchItem.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 // import OptionButton from "../../OptionButton";
 import FollowTypeButton from "@/components/FollowTypeButton";
 import { useCountryEmoji } from "@/hooks/useCountryEmoji";
@@ -8,23 +8,35 @@ import useModal from "@/hooks/useModal";
 import { ModalType } from "@/types/enum/modal.enum";
 import BoardOption from "@/components/BoardOption";
 import { currentMemberIdState } from "@/recoil/atom";
+import { callbackStoreState } from "@/recoil/atom";
 
-const SearchItem = (user: MemberSearchResponseDTO) => {
+interface SearchItemProps extends MemberSearchResponseDTO {
+  updateFollowType: () => void;
+  isMine: boolean;
+}
+
+const SearchItem = (props: SearchItemProps) => {
   const {
     memberId,
     memberName,
     intraName,
     profileImageUrl,
     country,
-    statement,
     relationship,
-  } = user;
+    updateFollowType,
+    isMine,
+  } = props;
 
   const { openModal } = useModal();
-  const setCurrentMemberId = useSetRecoilState(currentMemberIdState);
+  const setCurrentMemberId = useSetRecoilState<number | null>(
+    currentMemberIdState
+  );
+  const [callbackStore, setCallbackStore] =
+    useRecoilState<Function[]>(callbackStoreState);
 
   const handleOpenProfile = () => {
     setCurrentMemberId(memberId);
+    setCallbackStore([...callbackStore, updateFollowType]);
     openModal(ModalType.PROFILECARD);
   };
 
@@ -36,26 +48,36 @@ const SearchItem = (user: MemberSearchResponseDTO) => {
       <SearchItemRightStyled>
         <NameContainerStyled onClick={handleOpenProfile}>
           <MemberNameStyled>
-            {user.memberName}
-            {useCountryEmoji(user.country)}
+            {memberName} {useCountryEmoji(country)}
           </MemberNameStyled>
-          <IntraNameStyled>{user.intraName}</IntraNameStyled>
+          <IntraNameStyled>{intraName}</IntraNameStyled>
         </NameContainerStyled>
-        <SearchItemRightSideStyled>
-          <FollowTypeButton status={user.relationship} isLoading={false} />
-          <BufferStyled />
-          <BoardOption memberId={memberId} memberName={memberName} />
-        </SearchItemRightSideStyled>
+        {!isMine && (
+          <SearchItemRightSideStyled>
+            <FollowTypeButton
+              memberId={memberId}
+              status={relationship}
+              callback={updateFollowType}
+            />
+            <BufferStyled />
+            <BoardOption
+              memberId={memberId}
+              memberName={memberName}
+              callback={updateFollowType}
+            />
+          </SearchItemRightSideStyled>
+        )}
       </SearchItemRightStyled>
     </SearchItemStyled>
   );
 };
 
 const SearchItemStyled = styled.div`
+  height: 52px;
   display: flex;
-  padding: 10px;
-  width: 85%;
-  margin-bottom: 20px;
+  align-items: center;
+  width: 90%;
+  margin-bottom: 10px;
   margin-left: 10px;
   margin-right: 10px;
   border-radius: 30px;
@@ -66,10 +88,12 @@ const UserImageContainerStyled = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  margin-left: 11px;
   img {
     cursor: pointer;
-    width: 30px;
-    height: 30px;
+    width: 34px;
+    height: 34px;
     border-radius: 100%;
     border: 1px solid var(--transparent);
   }
@@ -87,26 +111,27 @@ const SearchItemRightStyled = styled.div`
 const NameContainerStyled = styled.div`
   display: flex;
   width: 60%;
-  font-weight: bold;
-  padding-left: 10px;
-  color: var(--white);
+  font-weight: 500;
+  padding-left: 2px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  span {
-    margin-top: 5px;
-    font-weight: 300;
-    font-size: 11px;
-  }
 `;
 
 const MemberNameStyled = styled.div`
-  font-size: 14px;
-  font-color: var(--white);
+  cursor: pointer;
+  font-size: 1.3rem;
+  color: var(--white);
 `;
 
 const IntraNameStyled = styled.div`
-  font-size: 10px;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--transparent2);
+  transition: all 0.3s ease;
+  &:hover {
+    color: var(--white);
+  }
 `;
 
 const SearchItemRightSideStyled = styled.div`
@@ -118,24 +143,5 @@ const SearchItemRightSideStyled = styled.div`
 const BufferStyled = styled.div`
   width: 10px;
 `;
-
-// const StateButtonStyled = styled.button`
-//   width: 22%;
-//   border-radius: 8px;
-//   text-align: center;
-//   border: 1px solid var(--white);
-//   background: rgba(183, 184, 215, 0.00);
-//   cursor: pointer;
-//   background-color: ${props => {
-//     if (props.rel === "FOLLOWING")
-//         return "var(--transparent)";
-//     else if (props.rel === "NONE")
-//         return "var(--lightpurple)";
-//     else if (props.rel === "BLOCKED")
-//         return "var(--purple)";
-//   }};
-//   color: var(--white);
-//   transition: background-color ease-in-out;
-// `;
 
 export default SearchItem;

--- a/frontend/src/components/RightSection/SearchSection/SearchSection.tsx
+++ b/frontend/src/components/RightSection/SearchSection/SearchSection.tsx
@@ -1,25 +1,32 @@
 import { styled, keyframes } from "styled-components";
 import { useEffect, useState } from "react";
-import { useRecoilState } from "recoil";
-import { searchInputState } from "@/recoil/atom";
-import { MemberSearchResponseDTO } from "@/types/dto/member.dto.ts";
+import {
+  MemberSearchResponseDTO,
+  UserInfoDTO,
+} from "@/types/dto/member.dto.ts";
 import SearchItem from "@/components/RightSection/SearchSection/SearchItem";
 import { axiosGetSearchResults } from "@/api/axios/axios.custom";
 import useDebounce from "@/hooks/useDebounce";
+import useToaster from "@/hooks/useToaster";
+import LoadingDotsAnimation from "@/components/loading/LoadingDotsAnimation";
+import { userInfoState } from "@/recoil/atom";
+import { useRecoilState } from "recoil";
 
 const SearchSection = () => {
+  const [userInfo] = useRecoilState<UserInfoDTO | null>(userInfoState);
   const [isInput, setIsInput] = useState(false);
-  const [searchInput, setSearchInput] =
-    useRecoilState<string>(searchInputState);
+  const [searchInput, setSearchInput] = useState<string>("");
   const { debounce } = useDebounce();
+  const { popToast } = useToaster();
   const [searchResults, setSearchResults] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const myInput = document.getElementById("search-input") as HTMLInputElement;
 
     const inputChangeHandler = () => {
       setSearchInput(myInput.value);
-      submitSearch();
+      updateSearchResult();
     };
 
     if (myInput) {
@@ -34,16 +41,19 @@ const SearchSection = () => {
   }, []);
 
   useEffect(() => {
-    debounce("search", submitSearch, 500);
+    setIsLoading(true);
+    debounce("search", updateSearchResult, 500);
   }, [searchInput]);
 
-  const submitSearch = async () => {
+  const updateSearchResult = async () => {
     if (searchInput == "") {
+      setIsLoading(false);
       setSearchResults([]);
       return;
     }
     const result = await axiosGetSearchResults(searchInput, 100, 0);
     setSearchResults(result);
+    setIsLoading(false);
   };
 
   const handleInputChange = async (
@@ -53,11 +63,11 @@ const SearchSection = () => {
   };
 
   const handleInputState = () => {
+    if (isInput) return;
     if (searchInput == "") {
+      popToast("검색 내용을 입력해주세요.", "N");
       setIsInput(true);
-      setTimeout(() => {
-        setIsInput(false);
-      }, 1000);
+      debounce("noSearchInput", () => setIsInput(false), 1000);
     }
   };
 
@@ -66,7 +76,6 @@ const SearchSection = () => {
   ) => {
     if (event.key == "Enter") {
       handleInputState();
-
       setSearchInput(searchInput);
     }
   };
@@ -76,12 +85,12 @@ const SearchSection = () => {
       <SearchBarStyled $isInput={isInput}>
         <input
           type="text"
-          placeholder="검색어를 입력해주세요..."
+          placeholder="검색어를 입력해주세요.."
           value={searchInput}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
         />
-        <button onClick={() => submitSearch()}>
+        <button onClick={() => updateSearchResult()}>
           <img src="/src/assets/search.png" />
         </button>
       </SearchBarStyled>
@@ -97,10 +106,20 @@ const SearchSection = () => {
               country={user.country}
               statement={user.statement}
               relationship={user.relationship}
+              updateFollowType={updateSearchResult}
+              isMine={userInfo?.memberId === user.memberId}
             />
           ))
         ) : (
-          <NoSearchMessageStyled>검색 결과가 없습니다</NoSearchMessageStyled>
+          <NoSearchMessageStyled>
+            {isLoading ? (
+              <div>
+                <LoadingDotsAnimation />
+              </div>
+            ) : (
+              <div>검색 결과가 없습니다</div>
+            )}
+          </NoSearchMessageStyled>
         )}
       </SearchItemWrapperStyled>
     </WrapperStyled>
@@ -125,17 +144,17 @@ const shakeAnimation = keyframes`
 	100% { transform: translateX(0); }
 `;
 
-const SearchBarStyled = styled.div`
+const SearchBarStyled = styled.div<{ $isInput: boolean }>`
   display: flex;
   justify-content: space-between;
-  padding: 13px;
-  margin-top: 20px;
+  padding: 10px 10px;
+  margin-top: 15px;
   width: 85%;
   border-radius: 30px;
   background: var(--transparent);
-  animation: ${($isInput) => ($isInput ? shakeAnimation : "none")} 0.5s;
-  // 검색 입력창
+  animation: ${({ $isInput }) => ($isInput ? shakeAnimation : "none")} 0.5s;
   input {
+    width: 90%;
     display: flex;
     border: none;
     background: none;
@@ -143,9 +162,10 @@ const SearchBarStyled = styled.div`
     padding-left: 10px;
     caret-color: var(--white);
     color: var(--white);
-    font-size: 1.6rem;
+
+    font-size: 1.3rem;
     &::placeholder {
-      color: var(--white);
+      color: var(--transparent2);
     }
   }
   // 검색 버튼
@@ -155,11 +175,11 @@ const SearchBarStyled = styled.div`
     border: none;
     background: transparent;
     cursor: pointer;
-    width: 22px;
-    height: 22px;
+    padding: 0;
+    padding-right: 5px;
     img {
-      width: 22px;
-      height: 22px;
+      width: 15px;
+      height: 15px;
     }
   }
 `;
@@ -170,14 +190,13 @@ const SearchItemWrapperStyled = styled.div`
   align-items: center;
   margin-top: 20px;
   width: 100%;
-  overflow-y: auto;
 `;
 
 const NoSearchMessageStyled = styled.div`
   display: flex;
   justify-content: center;
   padding: 10px;
-  font-size: 16px;
+  font-size: 1.3rem;
   color: var(--white);
   opacity: 0.7;
 `;

--- a/frontend/src/components/SettingButton.tsx
+++ b/frontend/src/components/SettingButton.tsx
@@ -3,6 +3,9 @@ import styled from "styled-components";
 import useModal from "@/hooks/useModal";
 import useRightSectionHandler from "@/hooks/useRightSectionHandler";
 import { ModalType } from "@/types/enum/modal.enum";
+import { getCookie } from "@/api/cookie/cookies";
+
+const token = getCookie("access_token");
 
 const SettingButton = () => {
   const [isToggled, setIsToggled] = useState<boolean>(false);
@@ -18,6 +21,14 @@ const SettingButton = () => {
     }
   };
 
+  const handleOpenAnimalFilterSection = () => {
+    if (!token) {
+      openModal(ModalType.LOGIN);
+      return;
+    }
+    openAnimalFilterSection();
+  };
+
   return (
     <WrapperStyled onMouseLeave={() => handleToggle("ON")}>
       <ToggleStyled onClick={() => handleToggle("OFF")}>
@@ -31,7 +42,7 @@ const SettingButton = () => {
             </MenuItemStyled>
           </MenuItemWrapperStyled>
           <MenuItemWrapperStyled>
-            <MenuItemStyled onClick={openAnimalFilterSection}>
+            <MenuItemStyled onClick={handleOpenAnimalFilterSection}>
               <img src="/src/assets/categoryW.png" />
             </MenuItemStyled>
           </MenuItemWrapperStyled>

--- a/frontend/src/components/loading/LoadingAnimation.tsx
+++ b/frontend/src/components/loading/LoadingAnimation.tsx
@@ -16,7 +16,7 @@ const LoadingAnimationStyled = styled.div`
   position: absolute;
   top: 0;
   bottom: 0;
-  width: 100vw;
+  width: 110vw;
   height: 4px;
   background: linear-gradient(
     124deg,

--- a/frontend/src/components/loading/LoadingCircleAnimation.tsx
+++ b/frontend/src/components/loading/LoadingCircleAnimation.tsx
@@ -13,8 +13,8 @@ const LoadingCircleAnimation = () => {
 const LoadingCircleAnimationStyled = styled.div`
   position: absolute;
   top: 50%;
-  width: 70px;
-  height: 70px;
+  width: 50px;
+  height: 50px;
 
   &:before {
     content: "";

--- a/frontend/src/components/loading/LoadingDotsAnimation.tsx
+++ b/frontend/src/components/loading/LoadingDotsAnimation.tsx
@@ -2,11 +2,11 @@ import styled, { keyframes } from "styled-components";
 import { followType } from "@/types/enum/followType.enum";
 
 interface Props {
-  status: followType;
+  status?: followType;
 }
 
 const LoadingDotsAnimation = ({ status }: Props) => {
-  return <LoadingSpinner $status={status} />;
+  return <LoadingSpinner $status={status ?? followType.NONE} />;
 };
 
 const spinAnimation = keyframes`

--- a/frontend/src/components/modals/DeleteModal/DeleteModal.tsx
+++ b/frontend/src/components/modals/DeleteModal/DeleteModal.tsx
@@ -54,19 +54,22 @@ const DeleteModal = () => {
               ? comments[comments.length - 1]
               : null;
 
-          const updatedBoards = prevData.map((board: IBoardInfo) => {
-            if (board.boardId === currentBoardId) {
-              return {
-                ...board,
-                commentCount: board.commentCount - 1,
-                previewCommentUser:
-                  (lastComment && lastComment.memberName) ?? null,
-                previewComment: (lastComment && lastComment.comment) ?? null,
-              };
-            }
-            return board;
-          });
-          return updatedBoards;
+          const updatedBoards = prevData.pages.map((page: IBoardInfo[]) =>
+            page.map((board: IBoardInfo) => {
+              if (board.boardId === currentBoardId) {
+                return {
+                  ...board,
+                  commentCount: board.commentCount - 1,
+                  previewCommentUser:
+                    (lastComment && lastComment.memberName) ?? null,
+                  previewComment: (lastComment && lastComment.comment) ?? null,
+                };
+              }
+              return board;
+            })
+          );
+
+          return { ...prevData, pages: updatedBoards };
         }
       );
     },
@@ -76,12 +79,15 @@ const DeleteModal = () => {
     onSuccess: async () => {
       await queryClient.setQueryData(
         ["boards", boardCategory],
-        (prevData: IBoardInfo[] | any) => {
+        (prevData: { pages: IBoardInfo[][] } | any) => {
           if (!prevData) return prevData;
-          const updatedBoards: IBoardInfo[] = prevData.filter(
-            (board: IBoardInfo) => board.boardId !== deleteInfo.boardId
+          const updatedBoards = prevData.pages.map((page: IBoardInfo[]) =>
+            page.filter(
+              (board: IBoardInfo) => board.boardId !== deleteInfo.boardId
+            )
           );
-          return updatedBoards;
+
+          return { ...prevData, pages: updatedBoards };
         }
       );
     },

--- a/frontend/src/components/modals/LoginModal/LoginModal.tsx
+++ b/frontend/src/components/modals/LoginModal/LoginModal.tsx
@@ -1,0 +1,66 @@
+import { useRecoilState } from "recoil";
+import { styled } from "styled-components";
+import ModalLayout from "@/components/modals/ModalLayout";
+import { ModalType } from "@/types/enum/modal.enum";
+import { currentOpenModalState } from "@/recoil/atom";
+import { ICurrentModalStateInfo } from "@/types/interface/modal.interface";
+
+const LoginModal: React.FC = () => {
+  const [currentOpenModal] = useRecoilState<ICurrentModalStateInfo>(
+    currentOpenModalState
+  );
+
+  const redirectLogin = () =>
+    window.location.replace(`${import.meta.env.VITE_AUTH_LOGIN}`);
+
+  return (
+    <ModalLayout
+      modalName={ModalType.LOGIN}
+      isOpen={currentOpenModal.loginModal}
+    >
+      <WrapperStyled>
+        <h1>🐶</h1>
+        <ContentStyled>로그인이 필요한 서비스입니다.</ContentStyled>
+        <button onClick={redirectLogin}>로그인</button>
+      </WrapperStyled>
+    </ModalLayout>
+  );
+};
+
+const WrapperStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 105px;
+  background-color: var(--white);
+  border-radius: 10px;
+  color: var(--grey);
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 500;
+    margin-top: 15px;
+    margin-bottom: 5px;
+  }
+  button {
+    cursor: pointer;
+    margin-top: 10px;
+    height: 50px;
+    width: 100%;
+    border: none;
+    background-color: transparent;
+    color: var(--grey);
+    border: none;
+    border-top: 0.5px solid #eaeaea;
+    font-weight: 500;
+    font-size: 1.2rem;
+  }
+`;
+
+const ContentStyled = styled.div`
+  font-size: 1rem;
+  font-weight: 400;
+  text-align: center;
+  padding: 0px 40px;
+`;
+
+export default LoginModal;

--- a/frontend/src/components/modals/ModalContainer.tsx
+++ b/frontend/src/components/modals/ModalContainer.tsx
@@ -7,6 +7,7 @@ import ProfileCardModal from "@/components/modals/ProfileCardModal/ProfileCardMo
 import ProfileEditModal from "@/components/modals/ProfileEditModal/ProfileEditModal";
 import DeleteModal from "@/components/modals/DeleteModal/DeleteModal";
 import LanguageModal from "@/components/modals/LanguageModal/LanguageModal";
+import LoginModal from "./LoginModal/LoginModal";
 import instance from "@/api/axios/axios.instance";
 import { STATUS_401_UNAUTHORIZED } from "@/types/constants/StatusCode";
 import useModal from "@/hooks/useModal";
@@ -24,7 +25,7 @@ const ModalContainer = () => {
     },
     (error) => {
       if (error.response?.status === STATUS_401_UNAUTHORIZED) {
-        openModal(ModalType.LANGUAGE);
+        openModal(ModalType.LOGIN);
       }
       return Promise.reject(error);
     }
@@ -38,6 +39,7 @@ const ModalContainer = () => {
       {currentOpenModal.deleteModal && <DeleteModal />}
       {currentOpenModal.profileEditModal && <ProfileEditModal />}
       {currentOpenModal.languageModal && <LanguageModal />}
+      {currentOpenModal.loginModal && <LoginModal />}
     </>
   );
 };

--- a/frontend/src/components/modals/ProfileCardModal/ProfileCardModal.tsx
+++ b/frontend/src/components/modals/ProfileCardModal/ProfileCardModal.tsx
@@ -16,8 +16,10 @@ import useModal from "@/hooks/useModal";
 import { useCountryEmoji } from "@/hooks/useCountryEmoji";
 import { Country } from "@/types/enum/country.enum";
 import FollowTypeButton from "../../FollowTypeButton";
+import { useQueryClient } from "@tanstack/react-query";
 
 const ProfileCardModal = () => {
+  const queryClient = useQueryClient();
   const [currentOpenModal] = useRecoilState<ICurrentModalStateInfo>(
     currentOpenModalState
   );
@@ -26,7 +28,7 @@ const ProfileCardModal = () => {
   const { fetchProfile } = useFetch();
   const { moveToMyProfile, moveToProfile } = useNavigateCustom();
   const { closeModal } = useModal();
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ["profile", currentMemberId],
     queryFn: fetchProfile,
     keepPreviousData: true,
@@ -67,6 +69,12 @@ const ProfileCardModal = () => {
             <BoardOption
               memberId={currentMemberId as number}
               memberName={profileData.memberName}
+              callback={() => {
+                queryClient.invalidateQueries([
+                  "profile",
+                  currentMemberId as number,
+                ]);
+              }}
             />
           )}
         </OptionButtonContainerStyled>
@@ -100,7 +108,12 @@ const ProfileCardModal = () => {
                 <FollowTypeButton
                   memberId={currentMemberId as number}
                   status={profileData.followType}
-                  isProfile={true}
+                  callback={() => {
+                    queryClient.invalidateQueries([
+                      "profile",
+                      currentMemberId as number,
+                    ]);
+                  }}
                 />
               </>
             ) : (

--- a/frontend/src/components/modals/ReportModal/ReportModal.tsx
+++ b/frontend/src/components/modals/ReportModal/ReportModal.tsx
@@ -70,6 +70,7 @@ const ReportModal: React.FC = () => {
       popToast("신고 사유를 선택해주세요.", "N");
       return;
     }
+    await closeModal(ModalType.REPORT);
     await axiosReport(
       reportUserInfo.reportedMemberId as number,
       content,
@@ -78,7 +79,6 @@ const ReportModal: React.FC = () => {
       reportUserInfo.commentId
     );
     popToast("신고가 접수됐습니다.", "P");
-    closeModal(ModalType.REPORT);
     resetReportUserInfo();
   };
 

--- a/frontend/src/hooks/useFetch.tsx
+++ b/frontend/src/hooks/useFetch.tsx
@@ -24,33 +24,34 @@ const useFetch = () => {
   const [boardCategory] = useRecoilState<Board>(boardCategoryState);
   const [currentMemberId] = useRecoilState<number | null>(currentMemberIdState);
 
-  const fetchBoards = async () => {
+  const fetchBoards = async (page?: number) => {
     try {
+      if (!page) page = 0;
       if (boardCategory === Board.DEFAULT) {
-        const response = await axiosGetBoards(30, 0);
+        const response = await axiosGetBoards(20, page);
         return response.result;
       }
       if (boardCategory === Board.TRENDING) {
-        const response = await axiosGetTrendingBoards(30, 0);
+        const response = await axiosGetTrendingBoards(20, page);
         return response.result;
       }
       if (boardCategory === Board.FOLLOWING) {
-        const response = await axiosGetFollowingBoards(30, 0);
+        const response = await axiosGetFollowingBoards(20, page);
         return response.result;
       }
       if (boardCategory === Board.MINE) {
-        const response = await axiosGetMyBoards(30, 0);
+        const response = await axiosGetMyBoards(1000, page);
         return response.result;
       }
       if (boardCategory === Board.OTHER) {
         if (!currentMemberId) {
           return;
         }
-        const response = await axiosGetOtherBoards(currentMemberId, 20, 0);
+        const response = await axiosGetOtherBoards(currentMemberId, 20, page);
         return response.result;
       }
       if (boardCategory === Board.SCRAPPED) {
-        const response = await axiosGetScrappedBoards(20, 0);
+        const response = await axiosGetScrappedBoards(20, page);
         return response.result;
       }
     } catch (error) {
@@ -79,7 +80,6 @@ const useFetch = () => {
       if (!currentMemberId) return;
       if (!userInfo || userInfo.memberId !== currentMemberId) {
         const response = await axiosGetProfile(currentMemberId);
-        console.log(response);
         return response;
       }
       const response = await axiosGetMyProfile();

--- a/frontend/src/hooks/useModal.tsx
+++ b/frontend/src/hooks/useModal.tsx
@@ -2,10 +2,13 @@ import { useRecoilState } from "recoil";
 import { currentOpenModalState } from "@/recoil/atom";
 import { ICurrentModalStateInfo } from "@/types/interface/modal.interface";
 import { ModalType } from "@/types/enum/modal.enum";
+import { callbackStoreState } from "@/recoil/atom";
 
 const useModal = () => {
   const [currentOpenModal, setCurrentOpenModal] =
     useRecoilState<ICurrentModalStateInfo>(currentOpenModalState);
+  const [callbackStore, setCallbackStore] =
+    useRecoilState<Function[]>(callbackStoreState);
 
   const openModal = (modalName: ModalType) => {
     setCurrentOpenModal({
@@ -14,6 +17,7 @@ const useModal = () => {
     });
   };
   const closeModal = (modalName: ModalType) => {
+    if (callbackStore.length !== 0) setCallbackStore([]);
     setCurrentOpenModal({
       ...currentOpenModal,
       [modalName]: false,

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import BoardTemplate from "@/components/Board/BoardTemplate";
@@ -10,25 +10,37 @@ import useFetch from "@/hooks/useFetch";
 import { IBoardInfo } from "@/types/interface/board.interface";
 import { useNavigate } from "react-router-dom";
 import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+import LoadingCircleAnimation from "@/components/loading/LoadingCircleAnimation";
 
 const MainPage = () => {
   const [boardCategory, setBoardCategory] =
     useRecoilState<Board>(boardCategoryState);
   const { fetchBoards } = useFetch();
   const navigator = useNavigate();
-  const {
-    isLoading,
-    isError,
-    data: boards,
-  } = useQuery({
-    queryKey: ["boards", boardCategory],
-    queryFn: fetchBoards,
-    keepPreviousData: true,
-  });
+  const [ref, inView] = useInView();
+  const { data, fetchNextPage, hasNextPage, isLoading, isError } =
+    useInfiniteQuery(
+      ["boards", boardCategory],
+      ({ pageParam = 0 }) => fetchBoards(pageParam),
+      {
+        getNextPageParam: (lastPage, allPages) => {
+          if (lastPage.length === 0) return undefined;
+          return allPages.length;
+        },
+        keepPreviousData: true,
+      }
+    );
 
   useEffect(() => {
     setBoardCategory(Board.DEFAULT);
   }, []);
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage]);
 
   if (isLoading) {
     return (
@@ -43,41 +55,47 @@ const MainPage = () => {
     navigator("/error");
   }
 
-  if (!boards.length) {
+  if (data?.pages[0].length === 0) {
     return (
       <WrapperStyled $boardExists={false}>
-        <NoBoardsStyled>
-          <img src="/src/assets/noBoard.png" />
-          게시물이 존재하지 않습니다
-        </NoBoardsStyled>
+        <NoBoardsStyled>게시물이 존재하지 않습니다</NoBoardsStyled>
       </WrapperStyled>
     );
   }
 
   return (
     <WrapperStyled $boardExists={true}>
-      {boards.map((board: IBoardInfo) => (
-        <BoardTemplate
-          key={board.boardId}
-          boardId={board.boardId}
-          memberId={board.memberId}
-          memberName={board.memberName}
-          intraName={board.intraName}
-          profileImageUrl={board.profileImageUrl}
-          country={board.country}
-          images={board.images}
-          categories={board.categories}
-          reactionCount={board.reactionCount}
-          commentCount={board.commentCount}
-          scrapped={board.scrapped}
-          reacted={board.reacted}
-          content={board.content}
-          previewCommentUser={board.previewCommentUser}
-          previewComment={board.previewComment}
-          createdAt={board.createdAt}
-        />
-      ))}
-      <BoardsEndStyled>더 이상 게시물이 존재하지 않습니다.</BoardsEndStyled>
+      {data?.pages.map((page) =>
+        page.map((board: IBoardInfo) => (
+          <BoardTemplate
+            key={board.boardId}
+            boardId={board.boardId}
+            memberId={board.memberId}
+            memberName={board.memberName}
+            intraName={board.intraName}
+            profileImageUrl={board.profileImageUrl}
+            country={board.country}
+            images={board.images}
+            categories={board.categories}
+            reactionCount={board.reactionCount}
+            commentCount={board.commentCount}
+            scrapped={board.scrapped}
+            reacted={board.reacted}
+            content={board.content}
+            previewCommentUser={board.previewCommentUser}
+            previewComment={board.previewComment}
+            createdAt={board.createdAt}
+          />
+        ))
+      )}
+      {hasNextPage && (
+        <FetchObserverStyled ref={ref}>
+          <LoadingCircleAnimation />
+        </FetchObserverStyled>
+      )}
+      {!hasNextPage && (
+        <BoardsEndStyled>더 이상 게시물이 존재하지 않습니다.</BoardsEndStyled>
+      )}
     </WrapperStyled>
   );
 };
@@ -102,13 +120,20 @@ const BoardsEndStyled = styled.div`
   color: var(--white);
 `;
 
+const FetchObserverStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+`;
+
 const NoBoardsStyled = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   color: var(--white);
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   opacity: 0.7;
   img {
     width: 50px;

--- a/frontend/src/pages/ProfilePage/Component/PhotoZoneComponent.tsx
+++ b/frontend/src/pages/ProfilePage/Component/PhotoZoneComponent.tsx
@@ -1,9 +1,6 @@
 import styled from "styled-components";
-import { useState, useEffect } from "react";
 import { IBoardInfo } from "@/types/interface/board.interface";
-// import { BoardsInfoDTO } from "@/types/dto/board.dto";
 import PostList from "./PostList";
-import { useNavigate } from "react-router-dom";
 import useNavigateCustom from "@/hooks/useNavigateCustom";
 import { Board } from "@/types/enum/board.category.enum";
 
@@ -76,6 +73,13 @@ const PhotoCategoryToggleStyled = styled.div`
     border: none;
     width: 50%;
     position: relative;
+    transition: all 0.3s ease;
+    &:nth-child(1) {
+      border-top-left-radius: 10px;
+    }
+    &:nth-child(2) {
+      border-top-right-radius: 10px;
+    }
   }
   // button:not(:last-child)::before {
   //   content: "";

--- a/frontend/src/pages/ProfilePage/Component/PostList.tsx
+++ b/frontend/src/pages/ProfilePage/Component/PostList.tsx
@@ -4,7 +4,6 @@ import { IBoardInfo } from "@/types/interface/board.interface";
 
 const PostList = (props: any) => {
   const { posts, onClickItem } = props;
-
   return (
     <>
       {posts.map((post: IBoardInfo) => {

--- a/frontend/src/pages/ProfilePage/MyProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage/MyProfilePage.tsx
@@ -22,14 +22,14 @@ const MyProfilePage = () => {
   const handleTabState = (newTabState: Board) => {
     setBoardCategory(newTabState);
   };
-
+  console.log(boardCategory);
   useEffect(() => {
     setBoardCategory(Board.MINE);
   }, []);
 
   const boardsQuery = useQuery<IBoardInfo[]>({
-    queryKey: ["boards", boardCategory],
-    queryFn: fetchBoards,
+    queryKey: ["profileBoards", boardCategory], // 여기서 boardCategory를 그냥 Board.MINE하는게?
+    queryFn: () => fetchBoards(0),
     keepPreviousData: true,
   });
 

--- a/frontend/src/pages/ProfilePage/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage/ProfilePage.tsx
@@ -26,8 +26,8 @@ const ProfilePage = () => {
   }, []); // 빈 배열을 넣어 마운트 시 한 번만 실행되도록 함
 
   const boardsQuery = useQuery<IBoardInfo[]>({
-    queryKey: ["boards", boardCategory], // 여기서 boardCategory를 그냥 Board.MINE하는게?
-    queryFn: fetchBoards,
+    queryKey: ["profileBoards", boardCategory], // 여기서 boardCategory를 그냥 Board.MINE하는게?
+    queryFn: () => fetchBoards(0),
     keepPreviousData: true,
   });
 

--- a/frontend/src/recoil/atom.ts
+++ b/frontend/src/recoil/atom.ts
@@ -6,7 +6,7 @@ import { Board } from "@/types/enum/board.category.enum";
 import { IBanUserInfo } from "@/types/interface/user.interface";
 import { IToastInfo } from "@/types/interface/toast.interface";
 import Translator from "@/languages/Translator";
-import { UserInfoDTO, ReportUserDTO } from "@/types/dto/member.dto";
+import { UserInfoDTO, ReportDTO } from "@/types/dto/member.dto";
 import { IDeleteInfo } from "@/types/interface/option.interface";
 
 export const userInfoState = atom<UserInfoDTO | null>({
@@ -89,6 +89,7 @@ export const currentOpenModalState = atom<ICurrentModalStateInfo>({
     profileCardModal: false,
     profileEditModal: false,
     languageModal: false,
+    loginModal: false,
   },
 });
 
@@ -106,7 +107,7 @@ export const banUserInfoState = atom<IBanUserInfo>({
   },
 });
 
-export const reportUserInfoState = atom<ReportUserDTO>({
+export const reportUserInfoState = atom<ReportDTO>({
   key: "reportUserInfo",
   default: {
     reportedMemberId: null,
@@ -130,7 +131,9 @@ export const languageState = atom<any>({
   default: Translator.en,
 });
 
-export const searchInputState = atom<string | null>({
-  key: "searchInput",
-  default: "",
+//검색창에서 프로필 카드 모달을 띄웠을 시 차단할 경우 프로필 카드 모달과 검색창 아이템의 팔로우 타입 버튼 모두 렌더링 해주기 위함
+//정보 업데이트 후 새롭게 fetch하기 위한 콜백 함수들을 배열로 저장 후 foreach로 일괄 실행
+export const callbackStoreState = atom<Function[]>({
+  key: "callbackStore",
+  default: [],
 });

--- a/frontend/src/types/enum/modal.enum.ts
+++ b/frontend/src/types/enum/modal.enum.ts
@@ -5,4 +5,5 @@ export enum ModalType {
   PROFILECARD = "profileCardModal",
   PROFILEEDIT = "profileEditModal",
   LANGUAGE = "languageModal",
+  LOGIN = "loginModal",
 }

--- a/frontend/src/types/interface/modal.interface.ts
+++ b/frontend/src/types/interface/modal.interface.ts
@@ -12,4 +12,5 @@ export interface ICurrentModalStateInfo {
   profileCardModal: boolean;
   profileEditModal: boolean;
   languageModal: boolean;
+  loginModal: boolean;
 }

--- a/frontend/src/types/interface/user.interface.ts
+++ b/frontend/src/types/interface/user.interface.ts
@@ -5,6 +5,7 @@
 export interface IBanUserInfo {
   memberId: number | null;
   userName: string;
+  callback?: () => void;
 }
 
 /**


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- 기존의 mainPage에서 useQuery로 관리하던 게시물 데이터를 무한 스크롤 적용을 위해 useInfiniteQueries로 바꾸어 주었습니다. 이에 따라 데이터 업데이트 시 리렌더링 발생에 대한 로직들 또한 수정해 주었습니다.

- SearchSection에서 FollowTypeButton을 사용할 수 있도록 하였고, 또 SearchSection이 열린 상태에서 ProfileCardModal을 띄웠을 때 팔로우 타입을 바꿔줬을 때, 양 컴포넌트 모두 리렌더링이 발생할 수 있도록 'callbackStore' atom을 추가하였습니다. callbackStore는 리렌더링을 위한 여러 컴포넌트의 callback 함수를 배열로 관리하다가 한번 사용 후 배열을 초기화하게 됩니다.

- 추가로 로그인 토큰이 없는 상태에서 401 에러가 발생하는 경우 login 유도 모달을 띄우는 작업을 진행하였습니다.

- 동물 카테고리 섹션은 토큰이 없는 상태에서 접근하지 못하도록 수정하였습니다. 401 에러와 같은 동작을 하게 됩니다.

https://github.com/42pet/42pet/issues/75
