### PR TITLE
[BE] FIX, FEAT: Board 이미지 비어있는 경우 에러처리 및 멤버 프로필 이미지 비어있을 때 null로 생성

### DIFF
--- a/backend/src/main/java/proj/pet/board/controller/BoardController.java
+++ b/backend/src/main/java/proj/pet/board/controller/BoardController.java
@@ -1,19 +1,17 @@
 package proj.pet.board.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import proj.pet.auth.domain.AuthGuard;
 import proj.pet.auth.domain.AuthLevel;
+import proj.pet.board.dto.BoardCreateRequestDto;
 import proj.pet.board.dto.BoardsPaginationDto;
 import proj.pet.board.service.BoardFacadeService;
-import proj.pet.category.domain.Species;
 import proj.pet.member.domain.UserSession;
 import proj.pet.member.dto.UserSessionDto;
-
-import java.util.List;
 
 import static proj.pet.auth.domain.AuthLevel.ANYONE;
 
@@ -71,10 +69,13 @@ public class BoardController {
 	@AuthGuard(level = AuthLevel.USER_OR_ADMIN)
 	public void createBoard(
 			@UserSession UserSessionDto userSessionDto,
-			@RequestPart(value = "mediaDataList") List<MultipartFile> mediaDataList,
-			@RequestPart(value = "categoryList") List<Species> categoryList,
-			@RequestPart(value = "content") String content) {
-		boardFacadeService.createBoard(userSessionDto, mediaDataList, categoryList, content);
+			@Valid @ModelAttribute BoardCreateRequestDto boardCreateRequestDto) {
+//			@RequestPart(value = "mediaDataList") List<MultipartFile> mediaDataList,
+//			@RequestPart(value = "categoryList") List<Species> categoryList,
+//			@RequestPart(value = "content") String content) {
+		boardFacadeService.createBoard(userSessionDto,
+				boardCreateRequestDto.getMediaDataList(), boardCreateRequestDto.getCategoryList(), boardCreateRequestDto.getContent());
+//				mediaDataList, categoryList, content);
 	}
 
 	@DeleteMapping("/{boardId}")

--- a/backend/src/main/java/proj/pet/board/domain/BoardMedia.java
+++ b/backend/src/main/java/proj/pet/board/domain/BoardMedia.java
@@ -37,6 +37,7 @@ public class BoardMedia extends IdentityDomain implements Validatable {
 		this.mediaUrl = mediaUrl;
 		this.index = index;
 		this.mediaType = mediaType;
+		System.out.println("board = " + board + ", mediaUrl = " + mediaUrl + ", index = " + index + ", mediaType = " + mediaType);
 		RuntimeExceptionThrower.checkValidity(this);
 	}
 

--- a/backend/src/main/java/proj/pet/board/dto/BoardCreateRequestDto.java
+++ b/backend/src/main/java/proj/pet/board/dto/BoardCreateRequestDto.java
@@ -1,5 +1,6 @@
 package proj.pet.board.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 public class BoardCreateRequestDto {
+	@NotNull
 	private final List<MultipartFile> mediaDataList;
 	private final List<Species> categoryList;
 	private final String content;

--- a/backend/src/main/java/proj/pet/member/contorller/MemberController.java
+++ b/backend/src/main/java/proj/pet/member/contorller/MemberController.java
@@ -1,35 +1,19 @@
 package proj.pet.member.contorller;
 
-import static proj.pet.auth.domain.AuthLevel.ANYONE;
-import static proj.pet.auth.domain.AuthLevel.USER_OR_ADMIN;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import proj.pet.auth.domain.AuthGuard;
 import proj.pet.board.dto.BoardsPaginationDto;
 import proj.pet.member.domain.UserSession;
-import proj.pet.member.dto.MemberCreateRequestDto;
-import proj.pet.member.dto.MemberLanguageChangeRequestDto;
-import proj.pet.member.dto.MemberMyInfoResponseDto;
-import proj.pet.member.dto.MemberNicknameValidateResponseDto;
-import proj.pet.member.dto.MemberProfileChangeRequestDto;
-import proj.pet.member.dto.MemberProfileChangeResponseDto;
-import proj.pet.member.dto.MemberProfileResponseDto;
-import proj.pet.member.dto.MemberSearchPaginationDto;
-import proj.pet.member.dto.UserSessionDto;
+import proj.pet.member.dto.*;
 import proj.pet.member.service.MemberFacadeService;
+
+import static proj.pet.auth.domain.AuthLevel.ANYONE;
+import static proj.pet.auth.domain.AuthLevel.USER_OR_ADMIN;
 
 @RestController
 @RequestMapping("/v1/members")

--- a/backend/src/main/java/proj/pet/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/proj/pet/member/service/MemberServiceImpl.java
@@ -78,8 +78,12 @@ public class MemberServiceImpl implements MemberService {
 	public void uploadMemberProfileImage(Long memberId, MultipartFile profileImageData) {
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(NOT_FOUND_MEMBER::asServiceException);
-		String profileImageUrl = memberImageManager.uploadMemberProfileImage(profileImageData);
-		member.changeProfileImageUrl(profileImageUrl);
+		if (profileImageData == null || profileImageData.isEmpty()) {
+			member.changeProfileImageUrl(null);
+		} else {
+			String profileImageUrl = memberImageManager.uploadMemberProfileImage(profileImageData);
+			member.changeProfileImageUrl(profileImageUrl);
+		}
 	}
 
 	/**

--- a/backend/src/test/java/proj/pet/board/controller/BoardControllerTest.java
+++ b/backend/src/test/java/proj/pet/board/controller/BoardControllerTest.java
@@ -47,13 +47,13 @@ import static proj.pet.testutil.testdouble.board.TestBoardMedia.DEFAULT_MEDIA_UR
 class BoardControllerTest extends E2ETest {
 	/*------------------------------UTIL------------------------------*/
 	private final static String BEARER = "Bearer ";
+	private PersistHelper persistHelper;
+
+	/*---------------------------TEST-DOUBLE---------------------------*/
 	@MockBean
 	private AmazonS3 amazonS3;
 	@MockBean
 	private BoardMediaManager boardMediaManager;
-	private PersistHelper persistHelper;
-
-	/*---------------------------TEST-DOUBLE---------------------------*/
 	private List<AnimalCategory> animalCategories;
 	private Member author;
 	private Member loginUser;

--- a/backend/src/test/java/proj/pet/board/controller/BoardControllerTest.java
+++ b/backend/src/test/java/proj/pet/board/controller/BoardControllerTest.java
@@ -1,12 +1,18 @@
 package proj.pet.board.controller;
 
+import com.amazonaws.services.s3.AmazonS3;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import proj.pet.board.domain.Board;
+import proj.pet.board.domain.BoardMediaManager;
 import proj.pet.board.dto.BoardInfoDto;
 import proj.pet.board.dto.BoardsPaginationDto;
 import proj.pet.category.domain.AnimalCategory;
@@ -30,6 +36,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -37,9 +45,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static proj.pet.testutil.testdouble.board.TestBoardMedia.DEFAULT_MEDIA_URL;
 
 class BoardControllerTest extends E2ETest {
-
 	/*------------------------------UTIL------------------------------*/
 	private final static String BEARER = "Bearer ";
+	@MockBean
+	private AmazonS3 amazonS3;
+	@MockBean
+	private BoardMediaManager boardMediaManager;
 	private PersistHelper persistHelper;
 
 	/*---------------------------TEST-DOUBLE---------------------------*/
@@ -326,9 +337,13 @@ class BoardControllerTest extends E2ETest {
 	}
 
 	@Nested
-	@Disabled("multi part file 사용하는 방법 모르겠어서 일단 패스")
 	@DisplayName("POST /v1/boards")
 	class CreateBoards {
+		@BeforeEach
+		void mockBoardImageManager() {
+			given(boardMediaManager.uploadMedia(any(), any())).willReturn(randomString());
+		}
+
 		@Test
 		@DisplayName("로그인한 사용자는 이미지를 업로드하고, 게시글을 생성할 수 있다.")
 		void createBoards() throws Exception {
@@ -340,21 +355,49 @@ class BoardControllerTest extends E2ETest {
 			MockMultipartFile multipartFile3 = new MockMultipartFile("mediaDataList", "filename-3.jpg", "image/jpeg", "image3".getBytes());
 
 			String token = stubToken(loginUser, LocalDateTime.now(), 28);
-			MockHttpServletRequestBuilder req = post("/v1/boards")
-					.header(HttpHeaders.AUTHORIZATION, BEARER + token)
-					.contentType(MediaType.MULTIPART_FORM_DATA)
-					.requestAttr("mediaDataList", List.of(multipartFile1, multipartFile2, multipartFile3))
-					.requestAttr("content", "content")
-					.requestAttr("categoryList", List.of(animalCategories.get(0).getSpecies().name(), animalCategories.get(1).getSpecies().name()));
+
+			MockHttpServletRequestBuilder req =
+					multipart("/v1/boards")
+							.file(multipartFile1)
+							.file(multipartFile2)
+							.file(multipartFile3)
+							.param("content", "content")
+							.param("categoryList", animalCategories.get(0).getSpecies().name())
+							.header(HttpHeaders.AUTHORIZATION, BEARER + token)
+							.contentType(MediaType.MULTIPART_FORM_DATA);
 
 			mockMvc.perform(req)
 					.andDo(print())
 					.andExpect(status().isOk())
-					.andExpect(jsonPath("result.content").value("content"))
-					.andExpect(jsonPath("result.categories.[*].species").value(
-							Matchers.contains(animalCategories.get(0).getSpecies().name(), animalCategories.get(1).getSpecies().name())))
-					.andExpect(jsonPath("result.images").value(
-							Matchers.contains(DEFAULT_MEDIA_URL + 0, DEFAULT_MEDIA_URL + 1, DEFAULT_MEDIA_URL + 2)));
+					.andDo(e -> {
+						Board board = em.createQuery("select b from Board b", Board.class)
+								.getSingleResult();
+						assertThat(board.getMember()).isEqualTo(loginUser);
+						assertThat(board.getContent()).isEqualTo("content");
+						assertThat(board.getMediaList()).hasSize(3);
+						assertThat(board.getCategoryFilters()).hasSize(1);
+					});
+		}
+
+		@DisplayName("빈 미디어 파일을 업로드하면 게시글을 생성할 수 없다.")
+		@Test
+		void createBoards2() throws Exception {
+			persistHelper.persist(author, loginUser)
+					.and().persist(animalCategories.get(0), animalCategories.get(1))
+					.flushAndClear();
+
+			String token = stubToken(loginUser, LocalDateTime.now(), 28);
+
+			MockHttpServletRequestBuilder req =
+					multipart("/v1/boards")
+							.param("content", "content")
+							.param("categoryList", animalCategories.get(0).getSpecies().name())
+							.header(HttpHeaders.AUTHORIZATION, BEARER + token)
+							.contentType(MediaType.MULTIPART_FORM_DATA);
+
+			mockMvc.perform(req)
+					.andDo(print())
+					.andExpect(status().isBadRequest());
 		}
 	}
 

--- a/backend/src/test/java/proj/pet/member/MemberControllerTest.java
+++ b/backend/src/test/java/proj/pet/member/MemberControllerTest.java
@@ -1,0 +1,138 @@
+package proj.pet.member;
+
+import com.amazonaws.services.s3.AmazonS3;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import proj.pet.category.domain.AnimalCategory;
+import proj.pet.member.domain.Member;
+import proj.pet.member.domain.MemberImageManager;
+import proj.pet.member.domain.MemberRole;
+import proj.pet.member.domain.OauthType;
+import proj.pet.testutil.PersistHelper;
+import proj.pet.testutil.test.E2ETest;
+import proj.pet.testutil.testdouble.category.TestAnimalCategory;
+import proj.pet.testutil.testdouble.member.TestMember;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MemberControllerTest extends E2ETest {
+
+	private final static String BEARER = "Bearer ";
+	private final LocalDateTime now = LocalDateTime.now();
+	private PersistHelper persistHelper;
+	@MockBean
+	private AmazonS3 amazonS3;
+	@MockBean
+	private MemberImageManager memberImageManager;
+	private List<AnimalCategory> animalCategories;
+
+	@BeforeEach
+	void setup() {
+		persistHelper = PersistHelper.start(em);
+		animalCategories = persistHelper.persistAndReturn(TestAnimalCategory.getAllSpeciesAsCategories());
+	}
+
+	private String randomString() {
+		return UUID.randomUUID().toString();
+	}
+
+	@Nested
+	@DisplayName("POST /v1/members")
+	class CreateMember {
+
+		private final String url = "/v1/members";
+
+		@BeforeEach
+		void mockMemberImageManager() {
+			given(memberImageManager.uploadMemberProfileImage(any())).willReturn(randomString());
+		}
+
+		@Test
+		@DisplayName("42 OAuth 사용자는 회원 가입을 할 수 있다.")
+		void createMember() throws Exception {
+			Member noneRegisteredMember = TestMember.builder()
+					.oauthName("sanan")
+					.oauthId("sadfasdf")
+					.oauthType(OauthType.FORTY_TWO)
+					.nickname("sanan")
+					.memberRole(MemberRole.NOT_REGISTERED)
+					.build().asMockEntity(1L);
+
+			String token = stubToken(noneRegisteredMember, now, 1);
+
+			MockMultipartFile imageFile = new MockMultipartFile("imageData", "test.jpg", "image/jpeg", "test".getBytes());
+			MockHttpServletRequestBuilder req = multipart(url)
+					.file(imageFile)
+					.cookie(new Cookie("access_token", token))
+					.param("memberName", "sanan")
+					.param("statement", "안녕하세요?")
+					.param("categoryFilters", animalCategories.get(0).getCategoryName())
+					.header(AUTHORIZATION, BEARER + token);
+
+			mockMvc.perform(req)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andDo(e -> {
+						Member member = em.find(Member.class, noneRegisteredMember.getId());
+						assertThat(member.getMemberRole()).isEqualTo(MemberRole.USER);
+						assertThat(member.getOauthProfile().getId()).isEqualTo(noneRegisteredMember.getOauthProfile().getId());
+						assertThat(member.getOauthProfile().getName()).isEqualTo(noneRegisteredMember.getOauthProfile().getName());
+						assertThat(member.getOauthProfile().getType()).isEqualTo(noneRegisteredMember.getOauthProfile().getType());
+						assertThat(member.getNickname()).isEqualTo("sanan");
+						assertThat(member.getStatement()).isEqualTo("안녕하세요?");
+					});
+		}
+
+		@DisplayName("프로필 이미지를 업로드하지 않으면 null로 입력된다.")
+		@Test
+		void createMember2() throws Exception {
+			Member noneRegisteredMember = TestMember.builder()
+					.oauthName("sanan")
+					.oauthId("sadfasdf")
+					.oauthType(OauthType.FORTY_TWO)
+					.nickname("sanan")
+					.memberRole(MemberRole.NOT_REGISTERED)
+					.build().asMockEntity(1L);
+
+			String token = stubToken(noneRegisteredMember, now, 1);
+
+			MockHttpServletRequestBuilder req = multipart(url)
+					.cookie(new Cookie("access_token", token))
+					.param("memberName", "sanan")
+					.param("statement", "안녕하세요?")
+					.param("categoryFilters", animalCategories.get(0).getCategoryName())
+					.header(AUTHORIZATION, BEARER + token);
+
+			mockMvc.perform(req)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andDo(e -> {
+						Member member = em.find(Member.class, noneRegisteredMember.getId());
+						assertThat(member.getMemberRole()).isEqualTo(MemberRole.USER);
+						assertThat(member.getOauthProfile().getId()).isEqualTo(noneRegisteredMember.getOauthProfile().getId());
+						assertThat(member.getOauthProfile().getName()).isEqualTo(noneRegisteredMember.getOauthProfile().getName());
+						assertThat(member.getOauthProfile().getType()).isEqualTo(noneRegisteredMember.getOauthProfile().getType());
+						assertThat(member.getNickname()).isEqualTo("sanan");
+						assertThat(member.getStatement()).isEqualTo("안녕하세요?");
+						assertThat(member.getProfileImageUrl()).isNull();
+					});
+		}
+
+	}
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42pet/issues/123

https://github.com/42pet/42pet/issues/

- 게시글 업로드, 멤버 생성 Test 추가.
- 게시글 업로드에서 이미지가 비어있는 경우에 생성되지 못하도록 처리.
- 멤버 생성에서 이미지가 비어있는 경우에 null로 이미지 url이 입력되도록 처리.

프론트 테스트를 위해 빠르게 merge함.
