### PR TITLE
[FE] FIX: heic파일 이미지 업로드 기능 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^4.32.6",
         "@tanstack/react-query-devtools": "^4.33.0",
         "axios": "^1.4.0",
+        "browser-image-compression": "^2.0.2",
         "canvas-confetti": "^1.6.0",
         "cors": "^2.8.5",
         "heic2any": "^0.0.4",
@@ -4899,6 +4900,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -11358,6 +11367,11 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "deploy": "npm run build && aws s3 sync ./dist s3://42paw-front-deploy --profile=mingkang && aws cloudfront create-invalidation --profile=mingkang --distribution-id E3G4X4QI6AZ8J1 --paths '/*'"
+    "deploy": "npm run build && aws s3 sync ./dist s3://42paw-front-deploy --profile=hyungnoh && aws cloudfront create-invalidation --profile=hyungnoh --distribution-id E3G4X4QI6AZ8J1 --paths '/*'"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,13 +8,14 @@
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "deploy": "npm run build && aws s3 sync ./dist s3://42paw-front-deploy --profile=hyungnoh && aws cloudfront create-invalidation --profile=hyungnoh --distribution-id E3G4X4QI6AZ8J1 --paths '/*'"
+    "deploy": "npm run build && aws s3 sync ./dist s3://42paw-front-deploy --profile=mingkang && aws cloudfront create-invalidation --profile=mingkang --distribution-id E3G4X4QI6AZ8J1 --paths '/*'"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.3",
     "@tanstack/react-query": "^4.32.6",
     "@tanstack/react-query-devtools": "^4.33.0",
     "axios": "^1.4.0",
+    "browser-image-compression": "^2.0.2",
     "canvas-confetti": "^1.6.0",
     "cors": "^2.8.5",
     "heic2any": "^0.0.4",

--- a/frontend/src/components/modals/ProfileEditModal/ProfileEditModal.tsx
+++ b/frontend/src/components/modals/ProfileEditModal/ProfileEditModal.tsx
@@ -132,15 +132,30 @@ const ProfileEditModal = () => {
     // test
     if (file) {
       if (file.type === "image/heic" || file.type === "image/HEIC") {
-        let blob = file;
-        heic2any({ blob: blob, toType: "image/webp" }).then(function (
-          resultBlob: any
-        ) {
-          file = new File([resultBlob], file!.name.split(".")[0] + ".webp", {
-            type: "image/webp",
-            lastModified: new Date().getTime(),
+        fetch(URL.createObjectURL(file))
+          .then((res) => res.blob())
+          .then((blob) => heic2any({ blob }))
+          .then((conversionResult) => {
+            setProfileInfo({
+              ...profileInfo,
+              imageData: conversionResult as Blob,
+              profileImageChanged: true,
+            });
+            const webpDataURL = URL.createObjectURL(conversionResult as Blob);
+            setImagePreview(webpDataURL);
+            return;
+            // conversionResult is a BLOB
+            // of the PNG formatted image
           });
-        });
+        // let blob = file;
+        // heic2any({ blob: blob, toType: "image/webp" }).then(function (
+        //   resultBlob: any
+        // ) {
+        //   file = new File([resultBlob], file!.name.split(".")[0] + ".webp", {
+        //     type: "image/webp",
+        //     lastModified: new Date().getTime(),
+        //   });
+        // });
       }
     }
     // test
@@ -158,6 +173,7 @@ const ProfileEditModal = () => {
         ctx.drawImage(imageBitmap, 0, 0);
         canvas.toBlob(async (webpBlob) => {
           if (webpBlob) {
+            alert("webpBlob : " + webpBlob + " / " + webpBlob?.type);
             setProfileInfo({
               ...profileInfo,
               imageData: webpBlob,

--- a/frontend/src/components/modals/ProfileEditModal/ProfileEditModal.tsx
+++ b/frontend/src/components/modals/ProfileEditModal/ProfileEditModal.tsx
@@ -135,21 +135,6 @@ const ProfileEditModal = () => {
       maxSizeMB: 1,
       maxWidthOrHeight: 2520,
     };
-    // const resizeFile = async () => {
-    //   try {
-    //     const compressedFile = await imageCompression(file!, options);
-    //     setProfileInfo({
-    //       ...profileInfo,
-    //       imageData: compressedFile as Blob,
-    //       profileImageChanged: true,
-    //     });
-    //     const webpDataURL = URL.createObjectURL(compressedFile as Blob);
-    //     setImagePreview(webpDataURL);
-    //     return;
-    //   } catch (error) {
-    //     console.log(error);
-    //   }
-    // };
     // test
     if (file) {
       if (file.type === "image/heic" || file.type === "image/HEIC") {
@@ -165,41 +150,16 @@ const ProfileEditModal = () => {
                 lastModified: new Date().getTime(),
               }
             );
-            alert("size: " + file.size);
-            // resizeFile();
           })
           .catch((e) => {
             alert(e);
           });
-        // resizeFile();
-        //   let blob = file;
-        //   heic2any({ blob: blob, toType: "image/webp" }).then(function (
-        //     resultBlob: any
-        //   ) {
-        //     file = new File([resultBlob], file!.name.split(".")[0] + ".webp", {
-        //       type: "image/webp",
-        //       lastModified: new Date().getTime(),
-        //     });
-        //   });
-        //   setProfileInfo({
-        //     ...profileInfo,
-        //     imageData: file,
-        //     profileImageChanged: true,
-        //   });
-        //   const webpDataURL = URL.createObjectURL(file);
-        //   setImagePreview(webpDataURL);
-        //   return;
-        // }
       }
-    }
-    // test
-    if (file) {
       const compressedFile = await imageCompression(file!, options);
       if (compressedFile.size > 10000000) {
         popToast("10MB 이하의 이미지만 업로드 가능합니다.", "N");
         return;
       }
-      alert("22");
       const imageBitmap = await createImageBitmap(compressedFile);
       const canvas = document.createElement("canvas");
       canvas.width = imageBitmap.width;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- 갤럭시 폰에서 직접 찍은 사진들 같은 경우에 heic파일로 저장됨.
- 해당 파일을 사용하려면 다른 파일로 바꿔야하고 heic2any라이브러리 사용.
- 다른 파일로 바뀌면 용량이 커져서 업로드가 안됨.
- 다시 해당 파일의 용량을 줄여야함.
- browser-image-compression라이브러리 사용.
- 해당 파일 바꾸고 나서 현재 canvas이용하는 방식을 적용할까말까 비교해봤는데 canvas다시 적용하는게 용량이 많이 줄어서
  다른 파일들과 똑같은 작업 거치도록 수정
