### PR TITLE
[FE] FIX: 회원가입 시에도 프로필이미지 업로드 변경사항 적용

### DIFF
--- a/frontend/src/components/processImage.tsx
+++ b/frontend/src/components/processImage.tsx
@@ -1,0 +1,103 @@
+import heic2any from "heic2any";
+import imageCompression from "browser-image-compression";
+import { SignUpInfoDTO } from "@/types/dto/member.dto";
+import { IChangeProfileInfo } from "@/types/interface/profileChange.interface";
+
+function isIChangeProfileInfo(obj: any): obj is IChangeProfileInfo {
+  // 여기서 obj의 특정 조건을 검사하여 IChangeProfileInfo 타입 여부를 반환
+  return obj && "profileImageChanged" in obj;
+}
+
+function isSignUpInfoDto(obj: any): obj is SignUpInfoDTO {
+  // 여기서 obj의 특정 조건을 검사하여 SignUpInfoDTO 타입 여부를 반환
+  return obj && "categoryFilters" in obj; // 실제 필드를 확인해야 합니다.
+}
+
+export default async function processImage<T>(
+  file: File,
+  profileInfo: T,
+  setProfileInfo: React.Dispatch<React.SetStateAction<T>>,
+  setImagePreview: React.Dispatch<React.SetStateAction<string>>
+): Promise<number> {
+  const options = {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 2520,
+  };
+
+  try {
+    if (file.type === "image/heic" || file.type === "image/HEIC") {
+      await fetch(URL.createObjectURL(file))
+        .then((res) => res.blob())
+        .then((blob) => heic2any({ blob, toType: "image/webp" }))
+        .then((conversionResult) => {
+          file = new File(
+            [conversionResult as Blob],
+            file.name.split(".")[0] + ".webp",
+            {
+              type: "image/webp",
+              lastModified: new Date().getTime(),
+            }
+          );
+          console.log(file);
+        })
+        .catch((error) => {
+          console.log(error);
+          return 1;
+        });
+    }
+
+    const compressedFile = await imageCompression(file, options);
+
+    if (compressedFile.size > 10000000) {
+      console.log("사진 용량은 10MB가 넘어갈 수 없습니다");
+      return 1;
+    }
+
+    const imageBitmap = await createImageBitmap(compressedFile);
+    const canvas = document.createElement("canvas");
+    canvas.width = imageBitmap.width;
+    canvas.height = imageBitmap.height;
+    const ctx = canvas.getContext("2d");
+
+    if (ctx) {
+      ctx.drawImage(imageBitmap, 0, 0);
+      canvas.toBlob(async (webpBlob) => {
+        if (webpBlob) {
+          // setProfileInfo 함수의 타입을 검사하고 분기 처리
+          if (isIChangeProfileInfo(profileInfo)) {
+            // MemberProfileChangeRequestDto 타입 처리
+            console.log("profileImageChanged");
+            setProfileInfo({
+              ...profileInfo,
+              imageData: webpBlob,
+              profileImageChanged: true,
+            });
+          } else if (isSignUpInfoDto(profileInfo)) {
+            console.log("SignUpInfoDTO");
+            // SignUpInfoDTO 타입 처리
+            setProfileInfo({
+              ...profileInfo,
+              imageData: webpBlob,
+            });
+          }
+          const webpDataURL = URL.createObjectURL(webpBlob);
+          setImagePreview(webpDataURL);
+        }
+      }, "image/webp");
+    }
+  } catch (error) {
+    console.log(error);
+    return 1;
+  }
+  return 0;
+}
+
+// const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+//   const file = e.target.files?.[0];
+//   if (file) {
+//     processImage(file);
+//   }
+// };
+
+// 외부에서 사용할 경우
+// processImage 함수를 import한 후 필요한 파일을 전달하여 사용합니다.

--- a/frontend/src/pages/SignUpPage/components/ProfileCard.tsx
+++ b/frontend/src/pages/SignUpPage/components/ProfileCard.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { Section, SectionType } from "@/pages/SignUpPage/SignUpPage";
 import { SignUpInfoDTO } from "@/types/dto/member.dto";
 import useToaster from "@/hooks/useToaster";
+import processImage from "@/components/processImage";
 
 /**
  * @registerData.memberName 유저가 설정한 닉네임
@@ -20,31 +21,17 @@ const ProfileCard = ({
   setRegisterData,
   step,
 }: IProfileCardProps) => {
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>("");
   const { popToast } = useToaster();
 
   const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      console.log(file.size);
-      if (file.size > 10000000) {
-        popToast("사진 용량은 10MB가 넘어갈 수 없습니다", "N");
+      if (
+        await processImage(file, registerData, setRegisterData, setImagePreview)
+      ) {
+        popToast("10MB 이하의 이미지만 업로드 가능합니다.", "N");
         return;
-      }
-      const imageBitmap = await createImageBitmap(file);
-      const canvas = document.createElement("canvas");
-      canvas.width = imageBitmap.width;
-      canvas.height = imageBitmap.height;
-      const ctx = canvas.getContext("2d");
-      if (ctx) {
-        ctx.drawImage(imageBitmap, 0, 0);
-        canvas.toBlob(async (webpBlob) => {
-          if (webpBlob) {
-            setRegisterData({ ...registerData, imageData: webpBlob });
-            const webpDataURL = URL.createObjectURL(webpBlob);
-            setImagePreview(webpDataURL);
-          }
-        }, "image/webp");
       }
     }
   };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

회원가입 시에 이미지 업로드 하는거랑 프로필 수정할 때 이미지 업로드 하는거랑 같은 방식으로 변경
- 이미지 처리하는 과정을 함수로 따로 빼서 가져와서 사용하도록 구현
### 문제
- 함수에 전달해야하는 인자의 타입이 약간 달랐음.(전달하는 useState 훅의 타입이 다름)
### 해결
- 보통은 간단하게 전달하는 매개변수에 대해서 다 정의하고 조건문으로 다르게 처리했을 듯
- 찾아보다보니 제네릭과 타입가드를 사용해서 처리하는 방식도 있다고 해서 한 번 적용해봄
- 간단한 프로젝트에서는 첫 번째 방법이 간단하겠지만 타입 안정성이나 재사용성이 좋다고 하여서 두 번째 방법으로 구현
