### PR TITLE
[FE] FIX: react-query Cache -> 항상 stale

### DIFF
--- a/frontend/src/hooks/useFetch.tsx
+++ b/frontend/src/hooks/useFetch.tsx
@@ -29,8 +29,7 @@ import { boardsLengthState } from "@/recoil/atom";
 const useFetch = (memberId?: number | null) => {
   const setBoardsLength = useSetRecoilState<number>(boardsLengthState);
   const resetBoardsLength = useResetRecoilState(boardsLengthState);
-  const [boardCategory, setBoardCategory] =
-    useRecoilState<Board>(boardCategoryState);
+  const setBoardCategory = useSetRecoilState<Board>(boardCategoryState);
   const setButtonToggled = useSetRecoilState(buttonToggledState);
   const [currentBoardId] = useRecoilState<number | null>(currentBoardIdState);
   const [userInfo, setUserInfo] = useRecoilState<UserInfoDTO | null>(
@@ -38,22 +37,22 @@ const useFetch = (memberId?: number | null) => {
   );
   const { translator } = useTranslator();
 
-  const fetchBoards = async (page?: number) => {
+  const fetchBoards = async (boardCategory: Board, page?: number) => {
     resetBoardsLength();
     try {
       if (!page) page = 0;
       if (boardCategory === Board.DEFAULT) {
-        const response = await axiosGetBoards(10, page);
+        const response = await axiosGetBoards(20, page);
         setBoardsLength(response.result.length);
         return response.result;
       }
       if (boardCategory === Board.TRENDING) {
-        const response = await axiosGetTrendingBoards(10, page);
+        const response = await axiosGetTrendingBoards(20, page);
         setBoardsLength(response.result.length);
         return response.result;
       }
       if (boardCategory === Board.FOLLOWING) {
-        const response = await axiosGetFollowingBoards(10, page);
+        const response = await axiosGetFollowingBoards(20, page);
         setBoardsLength(response.result.length);
         return response.result;
       }

--- a/frontend/src/hooks/useNavigateCustom.tsx
+++ b/frontend/src/hooks/useNavigateCustom.tsx
@@ -13,6 +13,7 @@ const useNavigateCustom = () => {
   const navigator = useNavigate();
 
   const moveToMain = () => {
+    setBoard(Board.DEFAULT);
     setIsRightSectionOpened(false);
     navigator("/");
   };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import { RecoilRoot } from "recoil";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
@@ -8,11 +7,9 @@ import "@/index.css";
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
-        <App />
-      </RecoilRoot>
-    </QueryClientProvider>
-  </React.StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
+  </QueryClientProvider>
 );

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -39,14 +39,15 @@ const MainPage = () => {
   const { data, fetchNextPage, hasNextPage, isError, isLoading } =
     useInfiniteQuery(
       ["boards", boardCategory],
-      ({ pageParam = 0 }) => fetchBoards(pageParam),
+      ({ pageParam = 0 }) => fetchBoards(boardCategory, pageParam),
       {
         getNextPageParam: (lastPage, allPages) => {
           if (!lastPage || lastPage.length === 0) return undefined;
           return allPages.length;
         },
-        refetchOnMount: false,
+        refetchOnMount: true,
         refetchOnWindowFocus: false,
+        staleTime: Infinity,
       }
     );
 

--- a/frontend/src/pages/MyProfileBoardsPage.tsx
+++ b/frontend/src/pages/MyProfileBoardsPage.tsx
@@ -28,12 +28,15 @@ const MyProfileBoardsPage = () => {
   const { data, fetchNextPage, hasNextPage, isError, isLoading } =
     useInfiniteQuery(
       ["boards", boardCategory],
-      ({ pageParam = 0 }) => fetchBoards(pageParam),
+      ({ pageParam = 0 }) => fetchBoards(Board.MINE, pageParam),
       {
         getNextPageParam: (lastPage, allPages) => {
           if (!lastPage || lastPage.length === 0) return undefined;
           return allPages.length;
         },
+        refetchOnMount: true,
+        refetchOnWindowFocus: false,
+        staleTime: Infinity,
       }
     );
   const [currentProfileBoardId] = useRecoilState(currentProfileBoardIdState);

--- a/frontend/src/pages/ProfileBoardsPage.tsx
+++ b/frontend/src/pages/ProfileBoardsPage.tsx
@@ -29,12 +29,15 @@ const ProfileBoardsPage = () => {
   const { data, fetchNextPage, hasNextPage, isError, isLoading } =
     useInfiniteQuery(
       ["boards", boardCategory],
-      ({ pageParam = 0 }) => fetchBoards(pageParam),
+      ({ pageParam = 0 }) => fetchBoards(Board.OTHER, pageParam),
       {
         getNextPageParam: (lastPage, allPages) => {
           if (!lastPage || lastPage.length === 0) return undefined;
           return allPages.length;
         },
+        refetchOnMount: true,
+        refetchOnWindowFocus: false,
+        staleTime: Infinity,
       }
     );
   const [currentProfileBoardId] = useRecoilState(currentProfileBoardIdState);

--- a/frontend/src/pages/ProfilePage/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage/ProfilePage.tsx
@@ -19,6 +19,9 @@ const ProfilePage = () => {
   const profileQuery = useQuery({
     queryKey: ["profile", Number(memberId)],
     queryFn: fetchProfile,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   });
   const setBoardCategory = useSetRecoilState<Board>(boardCategoryState);
 
@@ -30,9 +33,10 @@ const ProfilePage = () => {
 
   const boardsQuery = useQuery<IBoardInfo[]>({
     queryKey: ["profileBoards", Board.OTHER, memberId], // 여기서 boardCategory를 그냥 Board.MINE하는게?
-    queryFn: () => {
-      return fetchBoards(0);
-    }, // page는 0으로 고정(일단?)
+    queryFn: () => fetchBoards(Board.OTHER, 0),
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   });
 
   const isLoading = loading || profileQuery.isLoading || boardsQuery.isLoading;

--- a/frontend/src/recoil/atom.ts
+++ b/frontend/src/recoil/atom.ts
@@ -35,7 +35,7 @@ export const followingBoardsState = atom<BoardsInfoDTO>({
 /**MainPage에서 게시물 정렬하는 방식(default, trending, following)을 기억하는 state*/
 export const boardCategoryState = atom<Board>({
   key: "boardCategory",
-  default: Board.DEFAULT,
+  default: Board.NONE,
 });
 
 /**현재 게시물의 댓글 목록*/

--- a/frontend/src/types/enum/board.category.enum.ts
+++ b/frontend/src/types/enum/board.category.enum.ts
@@ -5,4 +5,5 @@ export enum Board {
   MINE = "MINE",
   OTHER = "OTHER",
   SCRAPPED = "SCRAPPED",
+  NONE = "NONE",
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

1. 기존에는 게시물, 프로필 데이터를 페이지 컴포넌트가 마운트 될 때마다, 윈도우 포커스가 갱신될 때마다 refetch를 시도했지만, cache된 데이터의 staleTime을 Infinity로 바꿈으로써 세션이 새로고침되기 전까지 캐시된 데이터가 존재한다면 api를 재요청하지 않습니다. api 요청을 감소하기 위해 이러한 조치를 취했습니다.

2. fetchBoard 함수에 새로운 매개변수로 boardCategory를 추가해 주었습니다. 기존 방식에서는 전역 변수 boardCategory를 참조해 이에 따른 분기 처리를 통한 api 요청을 하였는데, 가끔 boardCategory가 바뀌기 이전에 api 요청을 시도하여 불필요한 api 요청을 중복적으로 날리는 현상이 발견됐습니다. 가령, 클라이언트가 /my-profile에서 새로고침을 하면 default 카테고리와 mine 카테고리의 게시물을 동시에 요청하였습니다. 이를 해소하기 위해 위 조치를 취했습니다.