### PR TITLE
[FE] FEAT : 게시물, 댓글, 프로필 cache 로직 대거 변경

### DIFF
--- a/frontend/src/components/Board/BoardTemplateUtils.tsx
+++ b/frontend/src/components/Board/BoardTemplateUtils.tsx
@@ -1,0 +1,135 @@
+import { useMutation } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Board } from "@/types/enum/board.category.enum";
+import { IBoardInfo } from "@/types/interface/board.interface";
+import {
+  axiosScrap,
+  axiosUndoScrap,
+  axiosReactComment,
+  axiosUndoReactComment,
+} from "@/api/axios/axios.custom";
+
+const BoardTemplateUtils = (currentBoardId: number) => {
+  const queryClient = useQueryClient();
+  const mainBoardCategories = [Board.DEFAULT, Board.TRENDING, Board.FOLLOWING];
+
+  const scrapMutation = useMutation(() => axiosScrap(currentBoardId), {
+    onSuccess: async () => {
+      for (let i = 0; i < mainBoardCategories.length; i++) {
+        await queryClient.setQueryData(
+          ["boards", mainBoardCategories[i]],
+          (prevData: IBoardInfo[] | any) => {
+            if (!prevData) return prevData;
+
+            const updatedBoards = prevData.pages.map((page: IBoardInfo[]) =>
+              page.map((board: IBoardInfo) => {
+                if (board.boardId === currentBoardId) {
+                  return {
+                    ...board,
+                    scrapped: true,
+                  };
+                }
+                return board;
+              })
+            );
+
+            return { ...prevData, pages: updatedBoards };
+          }
+        );
+      }
+    },
+  });
+
+  const undoScrapMutation = useMutation(() => axiosUndoScrap(currentBoardId), {
+    onSuccess: async () => {
+      for (let i = 0; i < mainBoardCategories.length; i++) {
+        await queryClient.setQueryData(
+          ["boards", mainBoardCategories[i]],
+          (prevData: IBoardInfo[] | any) => {
+            if (!prevData) return prevData;
+
+            const updatedBoards = prevData.pages.map((page: IBoardInfo[]) =>
+              page.map((board: IBoardInfo) => {
+                if (board.boardId === currentBoardId) {
+                  return {
+                    ...board,
+                    scrapped: false,
+                  };
+                }
+                return board;
+              })
+            );
+
+            return { ...prevData, pages: updatedBoards };
+          }
+        );
+      }
+    },
+  });
+
+  const reactMutation = useMutation(
+    () => axiosReactComment(currentBoardId, "LIKE"),
+    {
+      onSuccess: async () => {
+        for (let i = 0; i < mainBoardCategories.length; i++) {
+          await queryClient.setQueryData(
+            ["boards", mainBoardCategories[i]],
+            (prevData: IBoardInfo[] | any) => {
+              if (!prevData) return prevData;
+
+              const updatedBoards = prevData.pages.map((page: IBoardInfo[]) =>
+                page.map((board: IBoardInfo) => {
+                  if (board.boardId === currentBoardId) {
+                    return {
+                      ...board,
+                      reacted: true,
+                      reactionCount: board.reactionCount + 1,
+                    };
+                  }
+                  return board;
+                })
+              );
+
+              return { ...prevData, pages: updatedBoards };
+            }
+          );
+        }
+      },
+    }
+  );
+
+  const undoReactMutation = useMutation(
+    () => axiosUndoReactComment(currentBoardId),
+    {
+      onSuccess: async () => {
+        for (let i = 0; i < mainBoardCategories.length; i++) {
+          await queryClient.setQueryData(
+            ["boards", mainBoardCategories[i]],
+            (prevData: IBoardInfo[] | any) => {
+              if (!prevData) return prevData;
+
+              const updatedBoards = prevData.pages.map((page: IBoardInfo[]) =>
+                page.map((board: IBoardInfo) => {
+                  if (board.boardId === currentBoardId) {
+                    return {
+                      ...board,
+                      reacted: false,
+                      reactionCount: board.reactionCount - 1,
+                    };
+                  }
+                  return board;
+                })
+              );
+
+              return { ...prevData, pages: updatedBoards };
+            }
+          );
+        }
+      },
+    }
+  );
+
+  return { scrapMutation, undoScrapMutation, reactMutation, undoReactMutation };
+};
+
+export default BoardTemplateUtils;

--- a/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
+++ b/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
@@ -11,7 +11,7 @@ import { IBoardInfo } from "@/types/interface/board.interface";
 import useFetch from "@/hooks/useFetch";
 import LoadingCircleAnimation from "@/components/loading/LoadingCircleAnimation";
 import { CommentInfoDTO } from "@/types/dto/board.dto";
-import { boardCategoryState, languageState } from "@/recoil/atom";
+import { languageState } from "@/recoil/atom";
 import useDebounce from "@/hooks/useDebounce";
 
 const isOnlyWhitespace = (str: string) => {
@@ -24,7 +24,6 @@ const CommentSection = () => {
   const { debounce } = useDebounce();
   const { fetchComments } = useFetch();
   const [currentBoardId] = useRecoilState<number | null>(currentBoardIdState);
-  const [boardCategory] = useRecoilState<Board>(boardCategoryState);
   const [comment, setComment] = useState<string>("");
   const queryClient = useQueryClient();
   const { data: comments, isLoading } = useQuery({

--- a/frontend/src/hooks/useFetch.tsx
+++ b/frontend/src/hooks/useFetch.tsx
@@ -1,6 +1,7 @@
 import { useRecoilState, useSetRecoilState, useResetRecoilState } from "recoil";
 import {
   boardCategoryState,
+  boardsTotalLengthState,
   currentBoardIdState,
   userInfoState,
 } from "@/recoil/atom";
@@ -25,6 +26,7 @@ import {
 import { buttonToggledState } from "@/components/BoardSortToggle";
 import useTranslator from "@/hooks/useTranslator";
 import { boardsLengthState } from "@/recoil/atom";
+import { IBoardTotalLengthInfo } from "@/types/interface/board.interface";
 
 const useFetch = (memberId?: number | null) => {
   const setBoardsLength = useSetRecoilState<number>(boardsLengthState);
@@ -36,6 +38,8 @@ const useFetch = (memberId?: number | null) => {
     userInfoState
   );
   const { translator } = useTranslator();
+  const [boardsTotalLength, setBoardsTotalLength] =
+    useRecoilState<IBoardTotalLengthInfo>(boardsTotalLengthState);
 
   const fetchBoards = async (boardCategory: Board, page?: number) => {
     resetBoardsLength();
@@ -44,16 +48,28 @@ const useFetch = (memberId?: number | null) => {
       if (boardCategory === Board.DEFAULT) {
         const response = await axiosGetBoards(20, page);
         setBoardsLength(response.result.length);
+        setBoardsTotalLength({
+          ...boardsTotalLength,
+          default: response.totalLength,
+        });
         return response.result;
       }
       if (boardCategory === Board.TRENDING) {
         const response = await axiosGetTrendingBoards(20, page);
         setBoardsLength(response.result.length);
+        setBoardsTotalLength({
+          ...boardsTotalLength,
+          trending: response.totalLength,
+        });
         return response.result;
       }
       if (boardCategory === Board.FOLLOWING) {
         const response = await axiosGetFollowingBoards(20, page);
         setBoardsLength(response.result.length);
+        setBoardsTotalLength({
+          ...boardsTotalLength,
+          following: response.totalLength,
+        });
         return response.result;
       }
       if (boardCategory === Board.MINE) {

--- a/frontend/src/hooks/useRightSectionHandler.tsx
+++ b/frontend/src/hooks/useRightSectionHandler.tsx
@@ -81,6 +81,17 @@ const useRightSectionHandler = () => {
     setIsRightSectionOpened(true);
   };
   const closeRightSection = () => {
+    // rightSection이 닫힐 때 transition 시간이 0.4s로 설정되어 있음. mount 때마다 refetch해오기 위해 닫힐 때마다 모두 false로 바꿔줌.
+    setTimeout(() => {
+      setRightSectionContent({
+        search: false,
+        comment: false,
+        follower: false,
+        following: false,
+        animalFilter: false,
+        bannedMember: false,
+      });
+    }, 400);
     setIsRightSectionOpened(false);
   };
 

--- a/frontend/src/pages/MyProfileBoardsPage.tsx
+++ b/frontend/src/pages/MyProfileBoardsPage.tsx
@@ -36,7 +36,6 @@ const MyProfileBoardsPage = () => {
         },
         refetchOnMount: true,
         refetchOnWindowFocus: false,
-        staleTime: Infinity,
       }
     );
   const [currentProfileBoardId] = useRecoilState(currentProfileBoardIdState);

--- a/frontend/src/pages/ProfileBoardsPage.tsx
+++ b/frontend/src/pages/ProfileBoardsPage.tsx
@@ -37,7 +37,6 @@ const ProfileBoardsPage = () => {
         },
         refetchOnMount: true,
         refetchOnWindowFocus: false,
-        staleTime: Infinity,
       }
     );
   const [currentProfileBoardId] = useRecoilState(currentProfileBoardIdState);

--- a/frontend/src/pages/ProfilePage/MyProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage/MyProfilePage.tsx
@@ -23,14 +23,12 @@ const MyProfilePage = () => {
     queryFn: fetchProfile,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    staleTime: Infinity,
   });
   const boardsQuery = useQuery<IBoardInfo[]>({
     queryKey: ["profileBoards", boardCategory], // 여기서 boardCategory를 그냥 Board.MINE하는게?
     queryFn: () => fetchBoards(boardCategory, 0),
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    staleTime: boardCategory === Board.MINE ? Infinity : 0,
   });
 
   const handleTabState = (newTabState: Board) => {

--- a/frontend/src/pages/ProfilePage/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage/ProfilePage.tsx
@@ -21,7 +21,6 @@ const ProfilePage = () => {
     queryFn: fetchProfile,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    staleTime: Infinity,
   });
   const setBoardCategory = useSetRecoilState<Board>(boardCategoryState);
 
@@ -36,7 +35,6 @@ const ProfilePage = () => {
     queryFn: () => fetchBoards(Board.OTHER, 0),
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    staleTime: Infinity,
   });
 
   const isLoading = loading || profileQuery.isLoading || boardsQuery.isLoading;

--- a/frontend/src/recoil/atom.ts
+++ b/frontend/src/recoil/atom.ts
@@ -8,6 +8,7 @@ import { IToastInfo } from "@/types/interface/toast.interface";
 import Translator from "@/languages/Translator";
 import { UserInfoDTO } from "@/types/dto/member.dto";
 import { IDeleteInfo } from "@/types/interface/option.interface";
+import { IBoardTotalLengthInfo } from "@/types/interface/board.interface";
 
 export const userInfoState = atom<UserInfoDTO | null>({
   key: "userInfo",
@@ -143,4 +144,13 @@ export const boardsLengthState = atom<number>({
 export const logoClickObserverState = atom<number>({
   key: "logoClickObserver",
   default: 0,
+});
+
+export const boardsTotalLengthState = atom<IBoardTotalLengthInfo>({
+  key: "boardsTotalLength",
+  default: {
+    default: Infinity,
+    trending: Infinity,
+    following: Infinity,
+  },
 });

--- a/frontend/src/types/interface/board.interface.ts
+++ b/frontend/src/types/interface/board.interface.ts
@@ -35,3 +35,9 @@ export interface IBoardInfo {
   createdAt: string;
   followType: followType;
 }
+
+export interface IBoardTotalLengthInfo {
+  default: number;
+  trending: number;
+  following: number;
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

1. 모든 페이지는 mount될 때마다 refetch를 시도합니다.
2. 메인 페이지 내애서 보드 카테고리를 변경할 경우, cache된 데이터를 보여주며 게시물의 업데이트로 인한 stale한 데이터에 대한 변경 적용은 mutation으로 처리해 주었습니다. 
