### PR TITLE
[FE] 댓글 유저 태그 기능 핫픽스 (닉네임 짤림, 다국어 지원, 모바일뷰 등) #146 

### DIFF
--- a/frontend/src/components/RightSection/CommentSection/CommentItem.tsx
+++ b/frontend/src/components/RightSection/CommentSection/CommentItem.tsx
@@ -46,8 +46,7 @@ const CommentItem = (commentInfo: CommentInfoDTO) => {
 
   const renderCommentText = (commentText: string) => {
     // match @ followed by word characters or dots until a space, comma, or end
-    const tagRegex = /@\w+(\.\w+)*/g;
-    // This will be used to find all the matches and their indices
+    const tagRegex = /@[\p{L}\p{N}]+/gu;
     const matches = [...commentText.matchAll(tagRegex)];
     const renderedComment = [];
     let lastIndex = 0;

--- a/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
+++ b/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
@@ -116,12 +116,15 @@ const CommentSection = () => {
     let left = commentRef.current?.offsetLeft || 0;
     if (commentRef.current && mirrorRef.current) {
       const mirrorDiv = mirrorRef.current;
+      const characterWidth = 6;
       mirrorDiv.textContent = commentRef.current.value.substring(
         0,
         commentRef.current.value.lastIndexOf("@") + tagSearchInput.length + 1
       );
-      const characterWidth = 6;
       left += mirrorDiv.textContent.length * characterWidth;
+      if (left + 180 > window.innerWidth) {
+        left = dropdownPosition.left;
+      }
     }
     setDropdownPosition({ top, left });
   };
@@ -433,9 +436,11 @@ const DropdownStyled = styled.div<{
   flex-direction: column;
   align-items: center;
   /* width: 50%; */
+  min-width: 180px;
   height: 160px;
   background-color: var(--lightpurple);
   border-radius: 20px;
+  padding: 10px 0 10px 0;
   overflow-y: scroll;
   overflow-x: hidden;
   z-index: 1;
@@ -465,15 +470,16 @@ const UserImageContainerStyled = styled.div`
   align-items: center;
   justify-content: center;
 
-  margin-left: 11px;
+  margin-left: 5px;
   img {
     cursor: pointer;
-    width: 34px;
-    height: 34px;
+    width: 20px;
+    height: 20px;
     aspect-ratio: 1 / 1;
     object-fit: cover;
     border-radius: 100%;
     border: 1px solid var(--transparent);
+    margin-right: 5px;
   }
 `;
 
@@ -483,8 +489,8 @@ const SearchItemRightStyled = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  margin-left: 10px;
-  margin-right: 10px;
+  /* margin-left: 10px;
+  margin-right: 10px; */
 `;
 
 const NameContainerStyled = styled.div`

--- a/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
+++ b/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
@@ -409,37 +409,6 @@ const MirrorInputContainerStyled = styled.div`
   border-top: 1px solid var(--transparent);
   padding-top: 2%;
   padding-bottom: 2%;
-  input {
-    height: 50%;
-    width: 68%;
-    border: none;
-    border-radius: 0;
-    border-bottom: 1px solid var(--white);
-    background-color: transparent;
-    color: var(--white);
-    outline: none;
-    font-size: 13px;
-    margin-top: 3px;
-  }
-  input::placeholder {
-    font-size: 13px;
-    color: var(--transparent);
-  }
-  button {
-    font-size: 13px;
-    cursor: pointer;
-    height: 29px;
-    width: 76px;
-    border-radius: 5px;
-    border: 1px solid var(--white);
-    background-color: transparent;
-    color: var(--white);
-    transition: all 0.3s ease;
-    &:hover {
-      background-color: var(--white);
-      color: var(--pink);
-    }
-  }
 `;
 
 const MirrorInputStyled = styled.div`
@@ -454,23 +423,6 @@ const MirrorInputStyled = styled.div`
   outline: none;
   font-size: 13px;
   margin-top: 3px;
-  /* white-space: pre-wrap;
-  position: absolute;
-  height: auto;
-  top: 0;
-  left: 0;
-  pointer-events: none;
-  font-size: 13px;
-  height: 50%;
-  width: 68%;
-  border: none;
-  border-radius: 0;
-  border-bottom: 1px solid var(--white);
-  outline: none;
-  margin-top: 3px;
-  @media (max-width: 1023px) {
-    width: 0%;
-  } */
 `;
 
 const DropdownStyled = styled.div<{

--- a/frontend/src/components/modals/UserNotFoundModal/UserNotFoundModal.tsx
+++ b/frontend/src/components/modals/UserNotFoundModal/UserNotFoundModal.tsx
@@ -3,10 +3,10 @@ import styled from "styled-components";
 import { ModalType } from "@/types/enum/modal.enum";
 import ModalLayout from "@/components/modals/ModalLayout";
 import { ICurrentModalStateInfo } from "@/types/interface/modal.interface";
-import { currentOpenModalState } from "@/recoil/atom";
+import { currentOpenModalState, languageState } from "@/recoil/atom";
 
 const UserNotFoundModal = () => {
-  // const [language] = useRecoilState<any>(languageState);
+  const [language] = useRecoilState<any>(languageState);
   const [currentOpenModal] = useRecoilState<ICurrentModalStateInfo>(
     currentOpenModalState
   );
@@ -17,7 +17,7 @@ const UserNotFoundModal = () => {
     >
       <WrapperStyled>
         <h1>🐶</h1>
-        <ContentStyled>유저를 찾을 수 없습니다.</ContentStyled>
+        <ContentStyled>{language.userNotFound}</ContentStyled>
       </WrapperStyled>
     </ModalLayout>
   );

--- a/frontend/src/languages/en.ts
+++ b/frontend/src/languages/en.ts
@@ -104,6 +104,7 @@ export const en = {
   loginDemand: "Login is required for this service.",
   uploadImageBrief: "Upload Image",
   deleteImageBrief: "Delete Image",
+  userNotFound: "User not found",
 
   // notification
   followMessage: "has started following",

--- a/frontend/src/languages/fr.ts
+++ b/frontend/src/languages/fr.ts
@@ -108,6 +108,7 @@ export const fr = {
   loginDemand: "La connexion est nécessaire pour ce service.",
   uploadImageBrief: "Télécharger une image",
   deleteImageBrief: "Supprimer une image",
+  userNotFound: "Utilisateur non trouvé",
 
   // notification
   followMessage: "a commencé à suivre",

--- a/frontend/src/languages/ger.ts
+++ b/frontend/src/languages/ger.ts
@@ -109,6 +109,7 @@ export const ger = {
   loginDemand: "Für diesen Dienst ist eine Anmeldung erforderlich.",
   uploadImageBrief: "Bild hochladen",
   deleteImageBrief: "Bild löschen",
+  userNotFound: "Benutzer nicht gefunden",
 
   // notification
   followMessage: "hat angefangen zu folgen",

--- a/frontend/src/languages/it.ts
+++ b/frontend/src/languages/it.ts
@@ -104,6 +104,7 @@ export const it = {
   loginDemand: "L'accesso è richiesto per questo servizio.",
   uploadImageBrief: "Carica immagine",
   deleteImageBrief: "Elimina immagine",
+  userNotFound: "Utente non trovato",
 
   // notification
   followMessage: "ha iniziato a seguire",

--- a/frontend/src/languages/jp.ts
+++ b/frontend/src/languages/jp.ts
@@ -104,6 +104,7 @@ export const jp = {
   loginDemand: "このサービスにはログインが必要です。",
   uploadImageBrief: "画像をアップロード",
   deleteImageBrief: "画像を削除",
+  userNotFound: "ユーザーが見つかりません",
 
   // notification
   followMessage: " がフォローし始めました",

--- a/frontend/src/languages/ko.ts
+++ b/frontend/src/languages/ko.ts
@@ -104,6 +104,7 @@ export const ko = {
   loginDemand: "로그인이 필요한 서비스입니다",
   uploadImageBrief: "이미지 수정",
   deleteImageBrief: "이미지 제거",
+  userNotFound: "유저를 찾을 수 없습니다",
 
   // notification
   followMessage: "님이 팔로우하기 시작했습니다",

--- a/frontend/src/languages/pt.ts
+++ b/frontend/src/languages/pt.ts
@@ -105,6 +105,7 @@ export const pt = {
   loginDemand: "O login é necessário para este serviço.",
   uploadImageBrief: "Carregar imagem",
   deleteImageBrief: "Excluir imagem",
+  userNotFound: "Utilizador não encontrado",
 
   // notification
   followMessage: "começou a seguir",

--- a/frontend/src/languages/spa.ts
+++ b/frontend/src/languages/spa.ts
@@ -107,6 +107,7 @@ export const spa = {
   loginDemand: "Es necesario iniciar sesión para este servicio.",
   uploadImageBrief: "Subir imagen",
   deleteImageBrief: "Eliminar imagen",
+  userNotFound: "Usuario no encontrado",
 
   // notification
   followMessage: "ha comenzado a seguirte",


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- 모바일 뷰에서 '@' 로 태깅하는 위치에 따라 유저 검색창이 화면을 넘어가는 문제 수정
- 검색창 크기 및 내부 요소 크기 조정으로 닉네임 짤림 현상 방지
- 태깅된 유저 클릭 시, 해당 유저가 존재하지 않을 경우 UserNotFound 모달에서 다국어를 지원하도록 수정
- 영어 이외의 유니코드 (다국어) 닉네임도 태깅 지원하도록 정규표현식 수정

https://github.com/42pet/42pet/issues/146
