### PR TITLE
[FE] FIX: 유저 태깅 핫픽스 to main #146

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -635,7 +635,6 @@ const axiosGetNotificationsURL = "/v1/notices/me";
 export const axiosGetNotifications = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosGetNotificationsURL);
-    console.log(response.data.result);
     return response.data.result;
   } catch (error) {
     throw error;

--- a/frontend/src/components/RightSection/CommentSection/CommentItem.tsx
+++ b/frontend/src/components/RightSection/CommentSection/CommentItem.tsx
@@ -45,8 +45,7 @@ const CommentItem = (commentInfo: CommentInfoDTO) => {
   };
 
   const renderCommentText = (commentText: string) => {
-    // match @ followed by word characters or dots until a space, comma, or end
-    const tagRegex = /@[\p{L}\p{N}]+/gu;
+    const tagRegex = /@[^@\s]+/gu;
     const matches = [...commentText.matchAll(tagRegex)];
     const renderedComment = [];
     let lastIndex = 0;

--- a/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
+++ b/frontend/src/components/RightSection/CommentSection/CommentSection.tsx
@@ -144,16 +144,25 @@ const CommentSection = () => {
   const handleOnchange = (e: any) => {
     const value = e.target.value;
     setComment(value);
-    const lastWord = value.split(/[\s\n]+/).pop();
-    if (lastWord.startsWith("@")) {
-      const searchInput = lastWord.slice(1);
-      setTagSearchInput(searchInput);
-      setShowDropdown(true);
-    } else {
-      setTagSearchInput("");
-      setTagSearchResults([]);
-      setShowDropdown(false);
+    const atPositions = [...value.matchAll(/@/g)].map((match) => match.index);
+
+    const lastAtPos =
+      atPositions.length > 0 ? atPositions[atPositions.length - 1] : -1;
+
+    if (lastAtPos !== -1) {
+      const afterAtText = value.substring(lastAtPos + 1);
+      const pos = e.target.selectionStart;
+      const isInTaggingArea =
+        pos > lastAtPos && afterAtText.indexOf(" ") === -1;
+      if (isInTaggingArea) {
+        const tag = afterAtText.split(/\s/)[0];
+        setTagSearchInput(tag);
+        setShowDropdown(true);
+        return;
+      }
     }
+    setTagSearchInput("");
+    setShowDropdown(false);
   };
 
   const selectUsertoTag = (userName: string) => {


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

![image](https://github.com/42PAW/42PAW/assets/14016311/54346a43-47c8-4ffb-88b9-fa2c8a5e0c96)

- 댓글에서 태깅된 유저를 표시할 때 '@' 부터 다음 공백까지 태그하도록 검색 정규표현식을 업데이트했습니다.
- 댓글 작성 중 공백 없이 연속해서 '@' 를 사용하여 태깅해도 문제가 없도록 CommentSection 의 '@' 검색 로직을 변경하였습니다.

https://github.com/42pet/42pet/issues/146
